### PR TITLE
feat(template): add create template API

### DIFF
--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -1,0 +1,97 @@
+import { Request, Response, RequestHandler } from "express";
+import { asyncHandler } from "../utils/async-handler.js";
+import prisma from "../lib/db.js";
+
+// POST /api/v1/templates
+export const createTemplate: RequestHandler = asyncHandler(
+	async (req: Request, res: Response) => {
+		const userId = res.locals.user.id as string;
+		const {
+			title,
+			description,
+			category,
+			iconSymbol,
+			images,
+			formId,
+			fields,
+			status,
+		} = req.body;
+
+		let resolvedFields = fields ?? [];
+
+		if (!fields && formId) {
+			const sourceForm = await prisma.form.findFirst({
+				where: { id: formId, userId },
+				select: { fields: true },
+			});
+
+			if (!sourceForm) {
+				res.status(404).json({
+					success: false,
+					message: "Source form not found or does not belong to you",
+				});
+				return;
+			}
+
+			resolvedFields = sourceForm.fields;
+		}
+
+		const template = await prisma.template.create({
+			data: {
+				title,
+				description,
+				category,
+				iconSymbol,
+				images: images ?? [],
+				fields: resolvedFields,
+				formId: formId ?? null,
+				status: status ?? "PUBLISHED",
+				createdById: userId,
+			},
+		});
+
+		res.status(201).json({ success: true, data: template });
+	}
+);
+
+// GET /api/v1/template
+
+export const listTemplates: RequestHandler = asyncHandler(
+	async (req: Request, res: Response) => {
+		const { category } = req.query;
+
+		const where: Record<string, unknown> = { status: "PUBLISHED" };
+		if (typeof category === "string" && category.length > 0) {
+			where.category = category;
+		}
+
+		const templates = await prisma.template.findMany({
+			where,
+			orderBy: [
+				{ featured: "desc" },
+				{ useCount: "desc" },
+				{ createdAt: "desc" },
+			],
+			select: {
+				id: true,
+				title: true,
+				description: true,
+				category: true,
+				iconSymbol: true,
+				images: true,
+				featured: true,
+				useCount: true,
+				createdAt: true,
+				createdBy: {
+					select: {
+						id: true,
+						name: true,
+						image: true,
+					},
+				},
+			},
+		});
+
+		res.json({ success: true, data: templates });
+	}
+);

--- a/apps/api/src/lib/template-schemas.ts
+++ b/apps/api/src/lib/template-schemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { FormDefinitionSchema } from "@repo/types";
+
+export const CreateTemplateSchema = z.object({
+  title: z.string().min(1, "Title is required").max(200),
+  description: z.string().max(2000).optional(),
+  category: z.string().max(100).optional(),
+  iconSymbol: z.string().max(10).optional(),
+  images: z
+    .array(z.string().url("Each image must be a valid URL"))
+    .max(5, "Maximum 5 images allowed")
+    .default([]),
+
+  // Either supply a formId to snapshot from, or provide fields directly
+  formId: z.string().optional(),
+  fields: FormDefinitionSchema.optional(),
+
+  // Publish immediately or save as draft
+  status: z.enum(["DRAFT", "PUBLISHED"]).default("PUBLISHED"),
+});
+
+export type CreateTemplateInput = z.infer<typeof CreateTemplateSchema>;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,6 +6,7 @@ import formRouter from "./form/form.routes";
 import responseRouter from "./form/response.routes";
 import publicRouter from "./public/public.routes";
 import oauthRouter from "./user/oauth.routes";
+import templateRouter from "./template/template.routes";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "../lib/auth";
 
@@ -22,5 +23,6 @@ router.use("/api/v1/admin/auth", adminAuthRouter);
 router.use("/api/v1/forms", formRouter);
 router.use("/api/v1/forms/:id/responses", responseRouter);
 router.use("/api/v1/public", publicRouter);
+router.use("/api/v1/templates", templateRouter);
 
 export default router;

--- a/apps/api/src/routes/template/template.routes.ts
+++ b/apps/api/src/routes/template/template.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth";
+import { validate } from "../../middleware/validate";
+import { CreateTemplateSchema } from "../../lib/template-schemas";
+import {
+  createTemplate,
+  listTemplates,
+} from "../../controllers/template.controller";
+
+const templateRouter: Router = Router();
+
+templateRouter.get("/", listTemplates);
+templateRouter.post("/", requireAuth, validate(CreateTemplateSchema), createTemplate);
+
+export default templateRouter;

--- a/packages/db/prisma/schema/templates.prisma
+++ b/packages/db/prisma/schema/templates.prisma
@@ -1,27 +1,45 @@
-// ============================================
-// TEMPLATES
-// ============================================
+// ============================================ 
+// TEMPLATES 
+// ============================================ 
+
+enum TemplateStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
 
 model Template {
-  id          String   @id @default(cuid())
+  id          String         @id @default(cuid())
   title       String
-  description String?  @db.Text
+  description String?        @db.Text
   category    String?
-
+  
   // Template structure (same format as Form.fields)
-  fields      Json     @default("[]")
-
+  fields      Json           @default("[]")
+  
   // Preview
-  iconSymbol  String?  @default("📋")
-
+  iconSymbol  String?        @default("📋")
+  images      String[]       @default([])
+  
+  // Status
+  status      TemplateStatus @default(DRAFT)
+  
+  // Source form (optional back-reference)
+  formId      String?
+  
+  // Owner
+  createdById String
+  createdBy   User           @relation(fields: [createdById], references: [id], onDelete: Cascade)
+  
   // Metadata
-  featured    Boolean  @default(false)
-  useCount    Int      @default(0)
-
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  featured    Boolean        @default(false)
+  useCount    Int            @default(0)
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
 
   @@index([featured])
   @@index([category])
+  @@index([createdById])
+  @@index([status])
   @@map("templates")
 }

--- a/packages/db/prisma/schema/user.prisma
+++ b/packages/db/prisma/schema/user.prisma
@@ -30,6 +30,7 @@ model User {
   forms         Form[]
   sessions      Session[]
   accounts      Account[]
+  templates     Template[]
 
   // Metadata
   createdAt     DateTime  @default(now())


### PR DESCRIPTION
## What's Changed

This PR introduces a Community Templates system that allows users to publish forms as reusable templates and browse publicly available templates created by other users.

Closes #47

### Key Implementation Details

#### 1. Database Schema Updates

Added a new `Template` model with support for:

* Template metadata (`title`, `description`, `category`)
* Form field snapshot storage using JSON
* Preview assets (`iconSymbol`, `images`)
* Template status management (`DRAFT`, `PUBLISHED`, `ARCHIVED`)
* Template ownership through `createdById`
* Optional source form reference via `formId`
* Community metrics (`featured`, `useCount`)

Updated the `User` model to include a `templates` relation.

Added indexes for:

* `category`
* `createdById`
* `status`
* `featured`

#### 2. Validation Layer

Created `CreateTemplateSchema` for template creation requests.

Validation includes:

* Required title validation
* Optional description, category, and icon support
* URL validation for template preview images
* Maximum image count enforcement
* Support for both direct field definitions and form snapshot creation
* Draft and published template states

#### 3. Template Creation API

Added:

`POST /api/v1/templates`

Implementation details:

* Requires authentication
* Supports creating templates from supplied form definitions
* Supports snapshotting an existing form using `formId`
* Verifies ownership of the source form before snapshot creation
* Associates templates with the authenticated user
* Stores templates as either drafts or published entries

Error handling:

* Returns `404 Not Found` if the referenced form does not exist or is not owned by the authenticated user

#### 4. Template Listing API

Added:

`GET /api/v1/templates`

Implementation details:

* Publicly accessible endpoint
* Returns only published templates
* Supports optional category-based filtering
* Orders results by:

  * Featured status
  * Usage count
  * Creation date

Response includes:

* Template metadata
* Preview information
* Creator information
* Usage statistics

#### 5. Route Registration

Registered template routes under:

`/api/v1/templates`

Available endpoints:

* `GET /api/v1/templates`
* `POST /api/v1/templates`

Template creation is protected using the existing authentication middleware.

---

## Community Template API

Added backend support for community templates, enabling:

* Publishing forms as reusable templates
* Snapshot-based template creation from existing forms
* Public template discovery
* Template categorization
* Ownership validation and access control

---

## Checklist

* [x] Code follows project conventions
* [x] API routes registered and protected where required
* [x] Schema validation implemented
* [x] Prisma schema updated
* [x] Documentation/comments updated where applicable

## Release Notes

Community Templates support has been added to the API. Authenticated users can now publish forms as reusable templates, while all users can browse published templates through the new templates endpoint.
