### PR TITLE
feat: implement dashboard and template APIs with pagination and filte…

### DIFF
--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -14,7 +14,7 @@ export const listForms: RequestHandler = asyncHandler(
 
     // 1. Extract query params
     const page = Math.max(1, parseInt(req.query.page as string) || 1);
-    const limit = Math.max(1, parseInt(req.query.limit as string) || 10);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 10));
     const search = req.query.search as string | undefined;
     const published = req.query.published as string | undefined;
     // 2. Build where clause
@@ -28,7 +28,8 @@ export const listForms: RequestHandler = asyncHandler(
       whereClause.published = published === "true";
     }
     // 3. Fetch data and count in parallel
-    const skip = (page - 1) * limit;
+    const parsedSkip = req.query.skip ? parseInt(req.query.skip as string) : undefined;
+    const skip = parsedSkip !== undefined && !isNaN(parsedSkip) ? parsedSkip : (page - 1) * limit;
 
     const [forms, total] = await Promise.all([
       prisma.form.findMany({

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import { FormDefinitionSchema } from "@repo/types";
@@ -8,28 +9,60 @@ import prisma from "../lib/db";
 // ============================================
 
 export const listForms: RequestHandler = asyncHandler(
-  async (_req: Request, res: Response) => {
+  async (req: Request, res: Response) => {
     const userId = res.locals.user.id as string;
 
-    const forms = await prisma.form.findMany({
-      where: { userId },
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        title: true,
-        description: true,
-        iconSymbol: true,
-        coverUrl: true,
-        published: true,
-        slug: true,
-        responseCount: true,
-        viewCount: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+    // 1. Extract query params
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit as string) || 10);
+    const search = req.query.search as string | undefined;
+    const published = req.query.published as string | undefined;
+    // 2. Build where clause
+    const whereClause: Prisma.FormWhereInput = { userId };
 
-    res.json({ success: true, data: forms });
+    if (search) {
+      whereClause.title = { contains: search, mode: "insensitive" };
+    }
+
+    if (published !== undefined) {
+      whereClause.published = published === "true";
+    }
+    // 3. Fetch data and count in parallel
+    const skip = (page - 1) * limit;
+
+    const [forms, total] = await Promise.all([
+      prisma.form.findMany({
+        where: whereClause,
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limit,
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          iconSymbol: true,
+          coverUrl: true,
+          published: true,
+          slug: true,
+          responseCount: true,
+          viewCount: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      }),
+      prisma.form.count({ where: whereClause })
+    ]);
+    // 4. Return paginated response
+    res.json({
+      success: true,
+      data: forms,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit)
+      }
+    });
   },
 );
 

--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -13,7 +13,7 @@ export const getOwnedTemplates: RequestHandler = asyncHandler(
 
         // 1. Extract query params
         const page = Math.max(1, parseInt(req.query.page as string) || 1);
-        const limit = Math.max(1, parseInt(req.query.limit as string) || 10);
+         const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 10));
         const search = req.query.search as string | undefined;
         const category = req.query.category as string | undefined;
 

--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -1,0 +1,68 @@
+import { Prisma } from "@prisma/client";
+import { Request, Response, RequestHandler } from "express";
+import { asyncHandler } from "../utils/async-handler";
+import prisma from "../lib/db";
+
+// ============================================
+// GET /api/v1/templates/owned — list user's owned templates
+// ============================================
+
+export const getOwnedTemplates: RequestHandler = asyncHandler(
+    async (req: Request, res: Response) => {
+        const userId = res.locals.user.id as string;
+
+        // 1. Extract query params
+        const page = Math.max(1, parseInt(req.query.page as string) || 1);
+        const limit = Math.max(1, parseInt(req.query.limit as string) || 10);
+        const search = req.query.search as string | undefined;
+        const category = req.query.category as string | undefined;
+
+        // 2. Build where clause
+        const whereClause: Prisma.TemplateWhereInput = { userId };
+
+
+        if (search) {
+            whereClause.title = { contains: search, mode: "insensitive" };
+        }
+
+        if (category) {
+            whereClause.category = category;
+        }
+
+        // 3. Fetch data and count in parallel
+        const skip = (page - 1) * limit;
+
+        const [templates, total] = await Promise.all([
+            prisma.template.findMany({
+                where: whereClause,
+                orderBy: { createdAt: "desc" },
+                skip,
+                take: limit,
+                select: {
+                    id: true,
+                    title: true,
+                    description: true,
+                    category: true,
+                    iconSymbol: true,
+                    featured: true,
+                    useCount: true,
+                    createdAt: true,
+                    updatedAt: true,
+                },
+            }),
+            prisma.template.count({ where: whereClause })
+        ]);
+
+        // 4. Return paginated response
+        res.json({
+            success: true,
+            data: templates,
+            meta: {
+                total,
+                page,
+                limit,
+                totalPages: Math.ceil(total / limit)
+            }
+        });
+    },
+);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,6 +6,7 @@ import formRouter from "./form/form.routes";
 import responseRouter from "./form/response.routes";
 import publicRouter from "./public/public.routes";
 import oauthRouter from "./user/oauth.routes";
+import templateRouter from "./template/template.routes";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "../lib/auth";
 
@@ -20,6 +21,7 @@ router.use("/api/v1/auth/manual", userAuthRouter);
 router.use("/api/v1/auth/oauth", oauthRouter);
 router.use("/api/v1/admin/auth", adminAuthRouter);
 router.use("/api/v1/forms", formRouter);
+router.use("/api/v1/templates", templateRouter);
 router.use("/api/v1/forms/:id/responses", responseRouter);
 router.use("/api/v1/public", publicRouter);
 

--- a/apps/api/src/routes/template/template.routes.ts
+++ b/apps/api/src/routes/template/template.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth";
+import { getOwnedTemplates } from "../../controllers/template.controller";
+
+const router: Router = Router();
+
+// GET /api/v1/templates/owned
+router.get("/owned", requireAuth, getOwnedTemplates);
+
+export default router;

--- a/packages/db/prisma/migrations/20260624063648_add_template_user_id/migration.sql
+++ b/packages/db/prisma/migrations/20260624063648_add_template_user_id/migration.sql
@@ -5,7 +5,7 @@
 
 */
 -- AlterTable
-ALTER TABLE "templates" ADD COLUMN     "userId" TEXT NOT NULL;
+ALTER TABLE "templates" ADD COLUMN "userId" TEXT;
 
 -- CreateIndex
 CREATE INDEX "templates_userId_idx" ON "templates"("userId");

--- a/packages/db/prisma/migrations/20260624063648_add_template_user_id/migration.sql
+++ b/packages/db/prisma/migrations/20260624063648_add_template_user_id/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `templates` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "templates" ADD COLUMN     "userId" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "templates_userId_idx" ON "templates"("userId");
+
+-- CreateIndex
+CREATE INDEX "templates_createdAt_idx" ON "templates"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "templates" ADD CONSTRAINT "templates_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema/templates.prisma
+++ b/packages/db/prisma/schema/templates.prisma
@@ -21,8 +21,8 @@ model Template {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  userId String
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String?
+  user   User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([featured])
   @@index([category])

--- a/packages/db/prisma/schema/templates.prisma
+++ b/packages/db/prisma/schema/templates.prisma
@@ -3,25 +3,30 @@
 // ============================================
 
 model Template {
-  id          String   @id @default(cuid())
+  id          String  @id @default(cuid())
   title       String
-  description String?  @db.Text
+  description String? @db.Text
   category    String?
 
   // Template structure (same format as Form.fields)
-  fields      Json     @default("[]")
+  fields Json @default("[]")
 
   // Preview
-  iconSymbol  String?  @default("📋")
+  iconSymbol String? @default("📋")
 
   // Metadata
-  featured    Boolean  @default(false)
-  useCount    Int      @default(0)
+  featured Boolean @default(false)
+  useCount Int     @default(0)
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  userId String
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([featured])
   @@index([category])
+  @@index([userId])
+  @@index([createdAt])
   @@map("templates")
 }

--- a/packages/db/prisma/schema/user.prisma
+++ b/packages/db/prisma/schema/user.prisma
@@ -28,6 +28,7 @@ model User {
 
   // Relations
   forms         Form[]
+  templates     Template[]
   sessions      Session[]
   accounts      Account[]
 


### PR DESCRIPTION
## Summary
Implemented the Dashboard API requirements, including paginated endpoints for fetching user forms and owned templates. Also updated the Prisma schema to support performant lookups for the `Template` model.

## Changes Made
- Updated `GET /api/v1/forms` to support pagination (`page`/`limit`), searching (by `title`), and filtering (`published` status).
- Created `GET /api/v1/templates/owned` to fetch a paginated, searchable, and filterable list of user-owned templates.
- Added `userId` field to the `Template` Prisma model.
- Added standard indexing on `createdAt` and `userId` to `Template` and generated the corresponding database migration.

## Testing
- [x] Local testing completed
- [x] Linting passes with 0 errors
- [x] Database migration applies successfully via Docker

## Related Issues
- Fixes #41

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added dashboard support for listing the current user’s forms with paging, title search, and draft/published filtering.
- Added a new “owned templates” endpoint so users can browse their own templates with paging, search, and category filtering.
- Linked templates to their owners in the data model and database so template ownership is tracked and can be queried efficiently.
- Added indexing support to improve dashboard list lookups and pagination performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->