### PR TITLE
feat: implement create form API, AI generate endpoint, and update for…

### DIFF
--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -92,8 +92,19 @@ export const createForm: RequestHandler = asyncHandler(
           // Store the full FormDefinition object as jsonb
           fields: definition,
         },
+        select: {
+          id: true, title: true, description: true, iconSymbol: true,
+          coverUrl: true, published: true, slug: true, type: true,
+          requireEmail: true, responseCount: true, viewCount: true,
+          fields: true, createdAt: true, updatedAt: true,
+        },
       });
-      res.status(201).json({ success: true, data: form });
+      const definitionResult = FormDefinitionSchema.safeParse(form.fields);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { fields: _fields, ...formWithoutFields } = form;
+      res.status(201).json({
+        success: true, data: { ...formWithoutFields, definition: definitionResult.success ? definitionResult.data : form.fields }
+      });
     } catch (err: unknown) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
         res.status(409).json({ success: false, message: "A form with this slug already exists" });
@@ -181,10 +192,18 @@ export const updateForm: RequestHandler = asyncHandler(
           id: true, title: true, description: true, iconSymbol: true,
           coverUrl: true, published: true, slug: true, type: true,
           requireEmail: true, responseCount: true, viewCount: true,
-          createdAt: true, updatedAt: true,
+          fields: true, createdAt: true, updatedAt: true,
         },
       });
-      res.json({ success: true, data: updated });
+      const definitionResult = FormDefinitionSchema.safeParse(updated.fields);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { fields: _fields, ...formWithoutFields } = updated;
+      res.json({
+        success: true, data: {
+          ...formWithoutFields,
+          definition: definitionResult.success ? definitionResult.data : updated.fields
+        }
+      });
     } catch (err: unknown) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err?.code === "P2002") {
         res.status(409).json({ success: false, message: "A form with this slug already exists" });

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -2,6 +2,7 @@ import { Prisma } from "@prisma/client";
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import { FormDefinitionSchema } from "@repo/types";
+import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
 
 // ============================================
@@ -75,8 +76,8 @@ export const listForms: RequestHandler = asyncHandler(
 export const createForm: RequestHandler = asyncHandler(
   async (req: Request, res: Response) => {
     const userId = res.locals.user.id as string;
-    const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition } =
-      req.body;
+    const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition, type } = req.body as CreateFormInput;
+
 
     const form = await prisma.form.create({
       data: {
@@ -87,6 +88,7 @@ export const createForm: RequestHandler = asyncHandler(
         iconSymbol,
         requireEmail,
         slug,
+        type,
         // Store the full FormDefinition object as jsonb
         fields: definition,
       },
@@ -144,8 +146,7 @@ export const updateForm: RequestHandler = asyncHandler(
       return;
     }
 
-    const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition } =
-      req.body;
+    const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition, type } = req.body as UpdateFormInput;
 
     const updated = await prisma.form.update({
       where: { id: req.params.id },
@@ -156,6 +157,7 @@ export const updateForm: RequestHandler = asyncHandler(
         ...(iconSymbol !== undefined && { iconSymbol }),
         ...(requireEmail !== undefined && { requireEmail }),
         ...(slug !== undefined && { slug }),
+        ...(type !== undefined && { type }),
         // Only update fields if definition was provided in the request
         ...(definition !== undefined && { fields: definition }),
       },
@@ -211,4 +213,25 @@ export const togglePublish: RequestHandler = asyncHandler(
 
     res.json({ success: true, data: updated });
   },
+);
+
+// ============================================
+// POST /api/v1/forms/generate — generate form with AI
+// ============================================
+
+export const generateForm: RequestHandler = asyncHandler(
+  async (req: Request, res: Response) => {
+    const { prompt } = req.body;
+
+    // TODO: Connect real LLM logic here later. 
+    // For now, return a basic mock structure so the frontend can test.
+    const dummyDefinition = {
+      version: "1.0",
+      elements: [
+        { id: "q1", type: "text", label: `AI generated question for: ${prompt || "General"}`, required: true }
+      ]
+    };
+
+    res.json({ success: true, data: { definition: dummyDefinition } });
+  }
 );

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -4,6 +4,7 @@ import { asyncHandler } from "../utils/async-handler";
 import { FormDefinitionSchema } from "@repo/types";
 import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
+import { error } from "console";
 
 // ============================================
 // GET /api/v1/forms — list user's forms
@@ -78,23 +79,29 @@ export const createForm: RequestHandler = asyncHandler(
     const userId = res.locals.user.id as string;
     const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition, type } = req.body as CreateFormInput;
 
-
-    const form = await prisma.form.create({
-      data: {
-        userId,
-        title,
-        description,
-        coverUrl,
-        iconSymbol,
-        requireEmail,
-        slug,
-        type,
-        // Store the full FormDefinition object as jsonb
-        fields: definition,
-      },
-    });
-
-    res.status(201).json({ success: true, data: form });
+    try {
+      const form = await prisma.form.create({
+        data: {
+          userId,
+          title,
+          description,
+          coverUrl,
+          iconSymbol,
+          requireEmail,
+          slug,
+          type,
+          // Store the full FormDefinition object as jsonb
+          fields: definition,
+        },
+      });
+      res.status(201).json({ success: true, data: form });
+    } catch (err: unknown) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+        res.status(409).json({ success: false, message: "A form with this slug already exists" });
+        return;
+      }
+      throw err;
+    }
   },
 );
 
@@ -108,7 +115,15 @@ export const getForm: RequestHandler = asyncHandler(
 
     const form = await prisma.form.findFirst({
       where: { id: req.params.id, userId },
+      select: {
+        id: true, title: true, description: true, iconSymbol: true,
+        coverUrl: true, published: true, slug: true, type: true,
+        requireEmail: true, responseCount: true, viewCount: true,
+        fields: true, // needed to parse into definition
+        createdAt: true, updatedAt: true,
+      },
     });
+
 
     if (!form) {
       res.status(404).json({ success: false, message: "Form not found" });
@@ -123,8 +138,9 @@ export const getForm: RequestHandler = asyncHandler(
       res.status(500).json({ success: false, message: "Form definition is malformed" });
       return;
     }
-
-    res.json({ success: true, data: { ...form, definition: definitionResult.data } });
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { fields: _fields, ...formWithoutFields } = form;
+    res.json({ success: true, data: { ...formWithoutFields, definition: definitionResult.data } });
   },
 );
 
@@ -148,22 +164,36 @@ export const updateForm: RequestHandler = asyncHandler(
 
     const { title, description, coverUrl, iconSymbol, requireEmail, slug, definition, type } = req.body as UpdateFormInput;
 
-    const updated = await prisma.form.update({
-      where: { id: req.params.id },
-      data: {
-        ...(title !== undefined && { title }),
-        ...(description !== undefined && { description }),
-        ...(coverUrl !== undefined && { coverUrl }),
-        ...(iconSymbol !== undefined && { iconSymbol }),
-        ...(requireEmail !== undefined && { requireEmail }),
-        ...(slug !== undefined && { slug }),
-        ...(type !== undefined && { type }),
-        // Only update fields if definition was provided in the request
-        ...(definition !== undefined && { fields: definition }),
-      },
-    });
+    try {
+      const updated = await prisma.form.update({
+        where: { id: req.params.id },
+        data: {
+          ...(title !== undefined && { title }),
+          ...(description !== undefined && { description }),
+          ...(coverUrl !== undefined && { coverUrl }),
+          ...(iconSymbol !== undefined && { iconSymbol }),
+          ...(requireEmail !== undefined && { requireEmail }),
+          ...(slug !== undefined && { slug }),
+          ...(type !== undefined && { type }),
+          ...(definition !== undefined && { fields: definition }),
 
-    res.json({ success: true, data: updated });
+        },
+        select: {
+          id: true, title: true, description: true, iconSymbol: true,
+          coverUrl: true, published: true, slug: true, type: true,
+          requireEmail: true, responseCount: true, viewCount: true,
+          createdAt: true, updatedAt: true,
+        },
+      });
+      res.json({ success: true, data: updated });
+    } catch (err: unknown) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err?.code === "P2002") {
+        res.status(409).json({ success: false, message: "A form with this slug already exists" });
+        return;
+      }
+      throw err;
+    }
+
   },
 );
 
@@ -209,7 +239,9 @@ export const togglePublish: RequestHandler = asyncHandler(
     const updated = await prisma.form.update({
       where: { id: req.params.id },
       data: { published: !form.published },
+      select: { id: true, published: true, updatedAt: true },
     });
+
 
     res.json({ success: true, data: updated });
   },

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -4,7 +4,6 @@ import { asyncHandler } from "../utils/async-handler";
 import { FormDefinitionSchema } from "@repo/types";
 import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
-import { error } from "console";
 
 // ============================================
 // GET /api/v1/forms — list user's forms

--- a/apps/api/src/lib/form-schemas.ts
+++ b/apps/api/src/lib/form-schemas.ts
@@ -2,6 +2,12 @@ import { z } from "zod";
 import { FormDefinitionSchema, FormResponseDataSchema } from "@repo/types";
 
 
+const FormTypeSchema = z
+  .string()
+  .trim()
+  .transform((value: string) => value.toUpperCase())
+  .pipe(z.enum(["SCROLL", "STEP", "CHAT"]));
+
 export const CreateFormSchema = z.object({
   title: z.string().min(1, "Title is required").max(200),
   description: z.string().max(1000).optional(),
@@ -14,7 +20,7 @@ export const CreateFormSchema = z.object({
     .min(3)
     .max(100)
     .optional(),
-  type: z.enum(["SCROLL", "STEP", "CHAT"]).default("SCROLL"),
+  type: FormTypeSchema.default("SCROLL"),
   definition: FormDefinitionSchema.default({ version: "1.0", elements: [] }),
 });
 
@@ -34,7 +40,7 @@ export const SubmitResponseSchema = z.object({
 });
 
 export const GenerateFormSchema = z.object({
-  prompt: z.string().optional()
+  prompt: z.string().trim().min(1, "Prompt cannot be empty").max(1000, "Prompt is too long").optional()
 });
 
 

--- a/apps/api/src/lib/form-schemas.ts
+++ b/apps/api/src/lib/form-schemas.ts
@@ -14,6 +14,7 @@ export const CreateFormSchema = z.object({
     .min(3)
     .max(100)
     .optional(),
+  type: z.enum(["SCROLL", "STEP", "CHAT"]).default("SCROLL"),
   definition: FormDefinitionSchema.default({ version: "1.0", elements: [] }),
 });
 
@@ -31,5 +32,10 @@ export const SubmitResponseSchema = z.object({
   email: z.string().email().optional(),
   data: FormResponseDataSchema,
 });
+
+export const GenerateFormSchema = z.object({
+  prompt: z.string().optional()
+});
+
 
 export type SubmitResponseInput = z.infer<typeof SubmitResponseSchema>;

--- a/apps/api/src/lib/form-schemas.ts
+++ b/apps/api/src/lib/form-schemas.ts
@@ -16,7 +16,7 @@ export const CreateFormSchema = z.object({
   requireEmail: z.boolean().default(true),
   slug: z
     .string()
-    .regex(/^[a-z0-9-]+$/, "Slug may only contain lowercase letters, numbers, and hyphens")
+    .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, "Slug must start and end with a letter or number, hyphens allowed between words")
     .min(3)
     .max(100)
     .optional(),
@@ -45,3 +45,4 @@ export const GenerateFormSchema = z.object({
 
 
 export type SubmitResponseInput = z.infer<typeof SubmitResponseSchema>;
+export type GenerateFormInput = z.infer<typeof GenerateFormSchema>;

--- a/apps/api/src/middleware/require-auth.ts
+++ b/apps/api/src/middleware/require-auth.ts
@@ -13,7 +13,7 @@ export const requireAuth: RequestHandler = asyncHandler(async (
   });
 
   if (!session) {
-    res.status(401).json({ error: "Unauthorized" });
+    res.status(401).json({ success: false, message: "Unauthorized" });
     return;
   }
 

--- a/apps/api/src/routes/form/form.routes.ts
+++ b/apps/api/src/routes/form/form.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { requireAuth } from "../../middleware/require-auth";
 import { validate } from "../../middleware/validate";
-import { CreateFormSchema, UpdateFormSchema } from "../../lib/form-schemas";
+import { CreateFormSchema, GenerateFormSchema, UpdateFormSchema } from "../../lib/form-schemas";
 import {
   listForms,
   createForm,
@@ -9,6 +9,7 @@ import {
   updateForm,
   deleteForm,
   togglePublish,
+  generateForm,
 } from "../../controllers/form.controller";
 
 const formRouter: Router = Router();
@@ -21,6 +22,7 @@ formRouter.post("/", validate(CreateFormSchema), createForm);
 formRouter.get("/:id", getForm);
 formRouter.patch("/:id", validate(UpdateFormSchema), updateForm);
 formRouter.delete("/:id", deleteForm);
+formRouter.post("/generate", validate(GenerateFormSchema), generateForm);
 formRouter.post("/:id/publish", togglePublish);
 
 export default formRouter;

--- a/packages/db/prisma/migrations/20260625051303_add_form_type/migration.sql
+++ b/packages/db/prisma/migrations/20260625051303_add_form_type/migration.sql
@@ -14,22 +14,26 @@
 CREATE TYPE "FormType" AS ENUM ('SCROLL', 'STEP', 'CHAT');
 
 -- DropIndex
-DROP INDEX "accounts_provider_providerAccountId_key";
+DROP INDEX IF EXISTS "accounts_provider_providerAccountId_key";
 
--- AlterTable
-ALTER TABLE "accounts" DROP COLUMN "provider",
-DROP COLUMN "providerAccountId",
-DROP COLUMN "type",
-ADD COLUMN     "accountId" TEXT NOT NULL,
-ADD COLUMN     "password" TEXT,
-ADD COLUMN     "providerId" TEXT NOT NULL;
+-- AlterTable (Accounts: Rename instead of drop)
+ALTER TABLE "accounts" RENAME COLUMN "provider" TO "providerId";
+ALTER TABLE "accounts" RENAME COLUMN "providerAccountId" TO "accountId";
+ALTER TABLE "accounts" ADD COLUMN "password" TEXT;
+ALTER TABLE "accounts" DROP COLUMN IF EXISTS "type";
 
--- AlterTable
-ALTER TABLE "forms" ADD COLUMN     "type" "FormType" NOT NULL DEFAULT 'SCROLL';
+-- AlterTable (Forms: Add Type)
+ALTER TABLE "forms" ADD COLUMN "type" "FormType" NOT NULL DEFAULT 'SCROLL';
 
--- AlterTable
-ALTER TABLE "users" DROP COLUMN "emailVerified",
-ADD COLUMN     "emailVerified" BOOLEAN NOT NULL DEFAULT false;
+-- AlterTable (Users: Safely convert emailVerified to boolean)
+ALTER TABLE "users" ALTER COLUMN "emailVerified" TYPE BOOLEAN USING (
+  CASE 
+    WHEN "emailVerified" IS NOT NULL THEN true 
+    ELSE false 
+  END
+);
+ALTER TABLE "users" ALTER COLUMN "emailVerified" SET DEFAULT false;
+ALTER TABLE "users" ALTER COLUMN "emailVerified" SET NOT NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "accounts_providerId_accountId_key" ON "accounts"("providerId", "accountId");

--- a/packages/db/prisma/migrations/20260625051303_add_form_type/migration.sql
+++ b/packages/db/prisma/migrations/20260625051303_add_form_type/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `provider` on the `accounts` table. All the data in the column will be lost.
+  - You are about to drop the column `providerAccountId` on the `accounts` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `accounts` table. All the data in the column will be lost.
+  - The `emailVerified` column on the `users` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - A unique constraint covering the columns `[providerId,accountId]` on the table `accounts` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `accountId` to the `accounts` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `providerId` to the `accounts` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "FormType" AS ENUM ('SCROLL', 'STEP', 'CHAT');
+
+-- DropIndex
+DROP INDEX "accounts_provider_providerAccountId_key";
+
+-- AlterTable
+ALTER TABLE "accounts" DROP COLUMN "provider",
+DROP COLUMN "providerAccountId",
+DROP COLUMN "type",
+ADD COLUMN     "accountId" TEXT NOT NULL,
+ADD COLUMN     "password" TEXT,
+ADD COLUMN     "providerId" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "forms" ADD COLUMN     "type" "FormType" NOT NULL DEFAULT 'SCROLL';
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "emailVerified",
+ADD COLUMN     "emailVerified" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "accounts_providerId_accountId_key" ON "accounts"("providerId", "accountId");

--- a/packages/db/prisma/schema/form.prisma
+++ b/packages/db/prisma/schema/form.prisma
@@ -1,42 +1,47 @@
 // ============================================
 // FORMS & RESPONSES
 // ============================================
+enum FormType {
+  SCROLL
+  STEP
+  CHAT
+}
 
 model Form {
-  id           String   @id @default(cuid())
-  title        String
-  description  String?  @db.Text
+  id          String  @id @default(cuid())
+  title       String
+  description String? @db.Text
 
   // Appearance
-  coverUrl     String?
-  iconSymbol   String?  @default("📝")
+  coverUrl   String?
+  iconSymbol String? @default("📝")
 
   // Settings
-  requireEmail Boolean  @default(true)
-  published    Boolean  @default(false)
-  slug         String?  @unique
-
+  requireEmail Boolean @default(true)
+  published    Boolean @default(false)
+  slug         String? @unique
+  type         FormType @default(SCROLL)
   // Form structure stored as JSON
   // Array of Field objects: { id, type, label, required?, options? }
-  fields       Json     @default("[]")
+  fields Json @default("[]")
 
   // Google Sheets integration
-  googleSheetId String?
+  googleSheetId  String?
   googleSheetUrl String?
 
   // Owner
-  userId       String
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // Relations
-  responses    Response[]
+  responses Response[]
 
   // Metadata
-  viewCount    Int      @default(0)
-  responseCount Int     @default(0)
+  viewCount     Int @default(0)
+  responseCount Int @default(0)
 
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([userId])
   @@index([published])
@@ -46,15 +51,15 @@ model Form {
 }
 
 model Response {
-  id        String   @id @default(cuid())
+  id String @id @default(cuid())
 
   // Related form
-  formId    String
-  form      Form     @relation(fields: [formId], references: [id], onDelete: Cascade)
+  formId String
+  form   Form   @relation(fields: [formId], references: [id], onDelete: Cascade)
 
   // Response data
-  email     String?
-  data      Json     @default("{}") // Field responses as key-value pairs { fieldId: value }
+  email String?
+  data  Json    @default("{}") // Field responses as key-value pairs { fieldId: value }
 
   // Metadata for analytics
   ipAddress String?


### PR DESCRIPTION
## Summary
Implemented the Create Form APIs block, allowing the client to safely create forms under an active session, define the structural format type of the form, and interface with future AI functionality.

## Changes Made
- Updated Prisma schema to include `FormType` enum (`SCROLL`, `STEP`, `CHAT`) and added the `type` column to the `Form` model.
- Refined `POST /api/v1/forms` to securely create forms under the session, mapping frontend "drag and drop snippets" correctly into the `definition` JSON.
- Updated `PATCH /api/v1/forms/:id` to support updating the `type` of the form post-creation.
- Implemented `POST /api/v1/forms/generate` as a placeholder logic endpoint to unblock frontend "AI Feature" development.
- Added and updated comprehensive Zod validation schemas (`CreateFormSchema`, `UpdateFormSchema`, `GenerateFormSchema`).

## Testing
- [x] Local testing and linting completed (`bun turbo lint` passes with 0 errors)
- [x] CodeRabbit issues preemptively fixed

## Related Issues
- Fixes #42

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Enable “Create Form” within the active app session flow to ensure forms are created in the correct user context.
- Add support for form types (`scroll`, `step`, `chat`) and allow changing the form type after creation.
- Persist drag-and-drop builder snippets into the form’s definition when creating/updating.
- Introduce a `/forms/generate` endpoint as a placeholder for future AI-based form generation.
- Align create/update/generate request validation to the new API shape for consistent inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->