### PR TITLE
feat(api): add POST /api/v1/templates to create community templates

### DIFF
--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -20,7 +20,8 @@ export const createTemplate: RequestHandler = asyncHandler(
             fields,
         } = req.body;
 
-        let resolvedFields = fields;
+        // Normalize direct fields input to store only the elements array
+        let resolvedFields = fields ? fields.elements : undefined;
         let verifiedFormId: string | null = null;
 
         // When formId is provided, verify ownership and snapshot the fields

--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -4,6 +4,62 @@ import { asyncHandler } from "../utils/async-handler";
 import prisma from "../lib/db";
 
 // ============================================
+// POST /api/v1/templates — publish a form as a community template
+// ============================================
+
+export const createTemplate: RequestHandler = asyncHandler(
+    async (req: Request, res: Response) => {
+        const userId = res.locals.user.id as string;
+        const {
+            title,
+            description,
+            category,
+            iconSymbol,
+            images,
+            formId,
+            fields,
+        } = req.body;
+
+        let resolvedFields = fields;
+        let verifiedFormId: string | null = null;
+
+        // When formId is provided, verify ownership and snapshot the fields
+        if (formId) {
+            const sourceForm = await prisma.form.findFirst({
+                where: { id: formId, userId },
+                select: { fields: true },
+            });
+
+            if (!sourceForm) {
+                res.status(404).json({
+                    success: false,
+                    message: "Source form not found or does not belong to you",
+                });
+                return;
+            }
+
+            resolvedFields = sourceForm.fields;
+            verifiedFormId = formId;
+        }
+
+        const template = await prisma.template.create({
+            data: {
+                title,
+                description,
+                category,
+                iconSymbol,
+                images: images ?? [],
+                fields: resolvedFields,
+                formId: verifiedFormId,
+                userId,
+            },
+        });
+
+        res.status(201).json({ success: true, data: template });
+    },
+);
+
+// ============================================
 // GET /api/v1/templates/owned — list user's owned templates
 // ============================================
 

--- a/apps/api/src/lib/template-schemas.ts
+++ b/apps/api/src/lib/template-schemas.ts
@@ -7,7 +7,12 @@ export const CreateTemplateSchema = z.object({
   category: z.string().max(100).optional(),
   iconSymbol: z.string().max(10).optional(),
   images: z
-    .array(z.string().url("Each image must be a valid URL"))
+    .array(
+      z
+        .string()
+        .url("Each image must be a valid URL")
+        .startsWith("http", "Only HTTP/HTTPS URLs are allowed")
+    )
     .max(5, "Maximum 5 images allowed")
     .default([]),
 

--- a/apps/api/src/lib/template-schemas.ts
+++ b/apps/api/src/lib/template-schemas.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { FormDefinitionSchema } from "@repo/types";
+
+export const CreateTemplateSchema = z.object({
+  title: z.string().min(1, "Title is required").max(200),
+  description: z.string().max(2000).optional(),
+  category: z.string().max(100).optional(),
+  iconSymbol: z.string().max(10).optional(),
+  images: z
+    .array(z.string().url("Each image must be a valid URL"))
+    .max(5, "Maximum 5 images allowed")
+    .default([]),
+
+  // Either supply a formId to snapshot from, or provide fields directly
+  formId: z.string().optional(),
+  fields: FormDefinitionSchema.optional(),
+}).refine((d) => Boolean(d.formId) !== Boolean(d.fields), {
+  message: "Provide exactly one of `formId` or `fields`",
+  path: ["fields"],
+});
+
+export type CreateTemplateInput = z.infer<typeof CreateTemplateSchema>;

--- a/apps/api/src/routes/template/template.routes.ts
+++ b/apps/api/src/routes/template/template.routes.ts
@@ -1,10 +1,18 @@
 import { Router } from "express";
 import { requireAuth } from "../../middleware/require-auth";
-import { getOwnedTemplates } from "../../controllers/template.controller";
+import { validate } from "../../middleware/validate";
+import { CreateTemplateSchema } from "../../lib/template-schemas";
+import {
+  createTemplate,
+  getOwnedTemplates,
+} from "../../controllers/template.controller";
 
 const router: Router = Router();
 
 // GET /api/v1/templates/owned
 router.get("/owned", requireAuth, getOwnedTemplates);
+
+// POST /api/v1/templates
+router.post("/", requireAuth, validate(CreateTemplateSchema), createTemplate);
 
 export default router;

--- a/packages/db/prisma/schema/form.prisma
+++ b/packages/db/prisma/schema/form.prisma
@@ -30,6 +30,7 @@ model Form {
 
   // Relations
   responses    Response[]
+  templates    Template[]
 
   // Metadata
   viewCount    Int      @default(0)

--- a/packages/db/prisma/schema/templates.prisma
+++ b/packages/db/prisma/schema/templates.prisma
@@ -33,5 +33,6 @@ model Template {
   @@index([category])
   @@index([userId])
   @@index([createdAt])
+  @@index([formId])
   @@map("templates")
 }

--- a/packages/db/prisma/schema/templates.prisma
+++ b/packages/db/prisma/schema/templates.prisma
@@ -13,6 +13,11 @@ model Template {
 
   // Preview
   iconSymbol String? @default("📋")
+  images     String[] @default([])
+
+  // Source form (optional back-reference)
+  formId String?
+  form   Form?   @relation(fields: [formId], references: [id], onDelete: SetNull)
 
   // Metadata
   featured Boolean @default(false)


### PR DESCRIPTION

# Create Template API

## Overview

This PR implements the **Create Template API**, allowing authenticated users to publish forms as community templates with image support and field snapshots.

### Key Design Decision

Templates remain functional even if their source form is deleted.

The `Template → Form` relation uses `onDelete: SetNull`, so when a form is removed:

- `formId` is automatically set to `null`
- The template itself is preserved
- The snapshotted field configuration remains intact
- Community templates never break due to form deletion

This ensures templates are self-contained and resilient.

## Changes Made

### Schema (`packages/db/prisma/schema/`)

#### Template Model

- Added `images String[] @default([])` for visual front-page display.
- Added `formId String?` with a proper relation to `Form`.
- Configured relation with `onDelete: SetNull`.

#### Form Model

- Added reverse relation:

```prisma
templates Template[]
````

### Validation (`apps/api/src/lib/template-schemas.ts`)

Created a new Zod schema that:

* Enforces `formId XOR fields` (exactly one must be provided).
* Validates image URLs (maximum 5 images).
* Validates:

  * `title` (1–200 characters)
  * `description` (maximum 2000 characters)
  * `category`
  * `iconSymbol`
* Ensures all image entries are valid URLs.

### Controller (`apps/api/src/controllers/template.controller.ts`)

Added `createTemplate` handler that:

* Verifies form ownership when `formId` is provided.
* Uses `findFirst` with `userId` verification.
* Snapshots form fields into the template's own `fields` JSON.
* Stores `formId` only after successful ownership verification.
* Returns `201 Created` with the created template.

### Routes (`apps/api/src/routes/template/template.routes.ts`)

Added:

```http
POST /api/v1/templates
```

with:

* `requireAuth`
* `validate(CreateTemplateSchema)`

middleware.

Existing route remains unchanged:

```http
GET /api/v1/templates/owned
```

## Data Integrity

### Form Deletion Safety

Templates survive source form deletion through:

```prisma
onDelete: SetNull
```

When a form is deleted:

* `formId` becomes `null`
* Template data remains available
* Snapshotted fields continue to work independently

### Ownership Protection

* Users can only create templates from forms they own.
* `formId` is persisted only after ownership verification.
* Prevents unauthorized template creation and reference leaks.

## Related Issues

Closes #47

## Checklist

* [x] Code follows project conventions
* [x] Lint passes with 0 errors
* [x] No new dependencies added
* [x] Schema changes are backward-compatible (additive only)

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Users can now publish their own forms as community templates via `POST /api/v1/templates`.
- Template publishing supports a cover image gallery (up to 5 images) plus optional description/category/icon details for stronger front-page presentation.
- Templates can be created either from an existing owned form (`formId`) or from provided field data (`fields`); requests require exactly one of these.
- When publishing from a form, the template snapshots the form’s current fields and remains available even if the original form is later deleted.
- Template creation requests are validated for required metadata and image URL correctness (HTTP/HTTPS only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->