### PR TITLE
Feat/onboarding flow

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lint": "eslint src/",
-    "dev": "bun run src/index.ts",
+    "dev": "bun --watch run src/index.ts",
     "build": "tsc"
   },
   "dependencies": {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,7 +5,12 @@ import { errorHandler } from "./middleware/error-handler";
 
 const app: express.Application = express();
 
-app.use(cors());
+app.use(
+  cors({
+    origin: process.env.FRONTEND_URL ?? "http://localhost:3001",
+    credentials: true,
+  })
+);
 app.use(express.json());
 
 app.use(router);

--- a/apps/api/src/controllers/onboarding.controller.ts
+++ b/apps/api/src/controllers/onboarding.controller.ts
@@ -1,0 +1,57 @@
+import { Request, Response, RequestHandler } from "express";
+import { asyncHandler } from "../utils/async-handler";
+import { OnboardingSchema } from "../lib/user-schemas";
+import prisma from "../lib/db";
+
+export const completeOnboarding: RequestHandler = asyncHandler(
+  async (req: Request, res: Response) => {
+    const user = res.locals.user;
+
+    // Validate request body
+    const parsed = OnboardingSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        success: false,
+        message: "Validation failed",
+        errors: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+
+    const { username, xUrl, linkedinUrl, instagramUrl } = parsed.data;
+
+    // Check if username is already taken by another user
+    const existing = await prisma.user.findUnique({ where: { username } });
+    if (existing && existing.id !== user.id) {
+      res.status(409).json({
+        success: false,
+        message: "Username is already taken",
+      });
+      return;
+    }
+
+    // Save onboarding data
+    const updated = await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        username,
+        xUrl: xUrl || null,
+        linkedinUrl: linkedinUrl || null,
+        instagramUrl: instagramUrl || null,
+        onboardingCompleted: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        email: true,
+        xUrl: true,
+        linkedinUrl: true,
+        instagramUrl: true,
+        onboardingCompleted: true,
+      },
+    });
+
+    res.status(200).json({ success: true, user: updated });
+  }
+);

--- a/apps/api/src/controllers/onboarding.controller.ts
+++ b/apps/api/src/controllers/onboarding.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import { OnboardingSchema } from "../lib/user-schemas";
 import prisma from "../lib/db";
+import { Prisma } from "@prisma/client";
 
 export const completeOnboarding: RequestHandler = asyncHandler(
   async (req: Request, res: Response) => {
@@ -20,16 +21,6 @@ export const completeOnboarding: RequestHandler = asyncHandler(
 
     const { username, socialLinks } = parsed.data;
 
-    // Check if username is already taken by another user
-    const existing = await prisma.user.findUnique({ where: { username } });
-    if (existing && existing.id !== user.id) {
-      res.status(409).json({
-        success: false,
-        message: "Username is already taken",
-      });
-      return;
-    }
-
     // Normalise empty strings to undefined so they aren't stored
     const cleanedLinks = {
       x: socialLinks.x || undefined,
@@ -37,24 +28,35 @@ export const completeOnboarding: RequestHandler = asyncHandler(
       instagram: socialLinks.instagram || undefined,
     };
 
-    // Save onboarding data
-    const updated = await prisma.user.update({
-      where: { id: user.id },
-      data: {
-        username,
-        socialLinks: cleanedLinks,
-        onboardingCompleted: true,
-      },
-      select: {
-        id: true,
-        name: true,
-        username: true,
-        email: true,
-        socialLinks: true,
-        onboardingCompleted: true,
-      },
-    });
+    try {
+      const updated = await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          username,
+          socialLinks: cleanedLinks,
+          onboardingCompleted: true,
+        },
+        select: {
+          id: true,
+          name: true,
+          username: true,
+          email: true,
+          socialLinks: true,
+          onboardingCompleted: true,
+        },
+      });
 
-    res.status(200).json({ success: true, user: updated });
+      res.status(200).json({ success: true, user: updated });
+    } catch (err) {
+      // Unique constraint on username — can happen under concurrent requests
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002"
+      ) {
+        res.status(409).json({ success: false, message: "Username is already taken" });
+        return;
+      }
+      throw err;
+    }
   }
 );

--- a/apps/api/src/controllers/onboarding.controller.ts
+++ b/apps/api/src/controllers/onboarding.controller.ts
@@ -18,7 +18,7 @@ export const completeOnboarding: RequestHandler = asyncHandler(
       return;
     }
 
-    const { username, xUrl, linkedinUrl, instagramUrl } = parsed.data;
+    const { username, socialLinks } = parsed.data;
 
     // Check if username is already taken by another user
     const existing = await prisma.user.findUnique({ where: { username } });
@@ -30,14 +30,19 @@ export const completeOnboarding: RequestHandler = asyncHandler(
       return;
     }
 
+    // Normalise empty strings to undefined so they aren't stored
+    const cleanedLinks = {
+      x: socialLinks.x || undefined,
+      linkedin: socialLinks.linkedin || undefined,
+      instagram: socialLinks.instagram || undefined,
+    };
+
     // Save onboarding data
     const updated = await prisma.user.update({
       where: { id: user.id },
       data: {
         username,
-        xUrl: xUrl || null,
-        linkedinUrl: linkedinUrl || null,
-        instagramUrl: instagramUrl || null,
+        socialLinks: cleanedLinks,
         onboardingCompleted: true,
       },
       select: {
@@ -45,9 +50,7 @@ export const completeOnboarding: RequestHandler = asyncHandler(
         name: true,
         username: true,
         email: true,
-        xUrl: true,
-        linkedinUrl: true,
-        instagramUrl: true,
+        socialLinks: true,
         onboardingCompleted: true,
       },
     });

--- a/apps/api/src/lib/user-schemas.ts
+++ b/apps/api/src/lib/user-schemas.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const optionalUrl = z
+  .string()
+  .url("Must be a valid URL")
+  .optional()
+  .or(z.literal(""));
+
+export const OnboardingSchema = z.object({
+  username: z
+    .string()
+    .min(3, "Username must be at least 3 characters")
+    .max(30, "Username must be 30 characters or fewer")
+    .regex(
+      /^[a-z0-9_]+$/,
+      "Only lowercase letters, numbers, and underscores allowed"
+    ),
+  xUrl: optionalUrl,
+  linkedinUrl: optionalUrl,
+  instagramUrl: optionalUrl,
+});
+
+export type OnboardingInput = z.infer<typeof OnboardingSchema>;

--- a/apps/api/src/lib/user-schemas.ts
+++ b/apps/api/src/lib/user-schemas.ts
@@ -15,9 +15,13 @@ export const OnboardingSchema = z.object({
       /^[a-z0-9_]+$/,
       "Only lowercase letters, numbers, and underscores allowed"
     ),
-  xUrl: optionalUrl,
-  linkedinUrl: optionalUrl,
-  instagramUrl: optionalUrl,
+  socialLinks: z
+    .object({
+      x: optionalUrl,
+      linkedin: optionalUrl,
+      instagram: optionalUrl,
+    })
+    .default({}),
 });
 
 export type OnboardingInput = z.infer<typeof OnboardingSchema>;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -6,6 +6,7 @@ import formRouter from "./form/form.routes";
 import responseRouter from "./form/response.routes";
 import publicRouter from "./public/public.routes";
 import oauthRouter from "./user/oauth.routes";
+import onboardingRouter from "./user/onboarding.routes";
 import templateRouter from "./template/template.routes";
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "../lib/auth";
@@ -20,6 +21,7 @@ router.all("/api/auth/*", toNodeHandler(auth));
 router.use("/api/v1/auth/manual", userAuthRouter);
 router.use("/api/v1/auth/oauth", oauthRouter);
 router.use("/api/v1/admin/auth", adminAuthRouter);
+router.use("/api/v1/user/onboarding", onboardingRouter);
 // NOTE: formRouter MUST be mounted before responseRouter.
 // formRouter handles GET /api/v1/forms/:id/responses/export/csv — if responseRouter
 // is mounted first, Express will intercept that path and return 404.

--- a/apps/api/src/routes/user/onboarding.routes.ts
+++ b/apps/api/src/routes/user/onboarding.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { requireAuth } from "../../middleware/require-auth";
+import { completeOnboarding } from "../../controllers/onboarding.controller";
+
+const router: Router = Router();
+
+router.post("/", requireAuth, completeOnboarding);
+
+export default router;

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,69 @@
+import { Card, CardContent } from "@repo/ui/components/ui/card";
+
+export default function DashboardPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md text-center space-y-6">
+
+        {/* Animated checkmark */}
+        <div className="flex justify-center">
+          <div className="relative w-20 h-20">
+            <div className="absolute inset-0 rounded-full bg-primary/10 animate-ping opacity-30" />
+            <div className="relative flex items-center justify-center w-20 h-20 rounded-full bg-primary/10">
+              <svg
+                className="w-9 h-9 text-primary"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </div>
+          </div>
+        </div>
+
+        {/* Heading */}
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            You&rsquo;re all set 🎉
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Welcome to your dashboard. Your profile is ready to go.
+          </p>
+        </div>
+
+        {/* Placeholder cards */}
+        <div className="grid grid-cols-2 gap-3 text-left">
+          <Card className="p-4 space-y-1 opacity-50 cursor-not-allowed select-none">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Forms
+            </div>
+            <div className="text-2xl font-bold">0</div>
+            <div className="text-xs text-muted-foreground">No forms yet</div>
+          </Card>
+
+          <Card className="p-4 space-y-1 opacity-50 cursor-not-allowed select-none">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Responses
+            </div>
+            <div className="text-2xl font-bold">0</div>
+            <div className="text-xs text-muted-foreground">No responses yet</div>
+          </Card>
+        </div>
+
+        {/* Coming soon notice */}
+        <Card>
+          <CardContent className="py-5">
+            <p className="text-sm text-muted-foreground">
+              🚧 &nbsp;Dashboard is under construction. More features coming soon.
+            </p>
+          </CardContent>
+        </Card>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@repo/ui/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@repo/ui/components/ui/card";
+import { Input } from "@repo/ui/components/ui/input";
+import { Label } from "@repo/ui/components/ui/label";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3000";
+
+// Simple inline SVG icons to avoid extra deps
+function XIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.264 5.638L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77z" />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function InstagramIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z" />
+    </svg>
+  );
+}
+
+type FormState = {
+  username: string;
+  xUrl: string;
+  linkedinUrl: string;
+  instagramUrl: string;
+};
+
+type FieldError = Partial<Record<keyof FormState, string>>;
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [form, setForm] = useState<FormState>({
+    username: "",
+    xUrl: "",
+    linkedinUrl: "",
+    instagramUrl: "",
+  });
+  const [errors, setErrors] = useState<FieldError>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+    // Clear the error for the field being edited
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    setServerError(null);
+  }
+
+  function validate(): boolean {
+    const next: FieldError = {};
+    if (!form.username) {
+      next.username = "Username is required";
+    } else if (!/^[a-z0-9_]{3,30}$/.test(form.username)) {
+      next.username =
+        "3–30 chars, lowercase letters, numbers, underscores only";
+    }
+    const urlPattern = /^https?:\/\/.+/;
+    if (form.xUrl && !urlPattern.test(form.xUrl))
+      next.xUrl = "Must be a valid URL (e.g. https://x.com/you)";
+    if (form.linkedinUrl && !urlPattern.test(form.linkedinUrl))
+      next.linkedinUrl =
+        "Must be a valid URL (e.g. https://linkedin.com/in/you)";
+    if (form.instagramUrl && !urlPattern.test(form.instagramUrl))
+      next.instagramUrl =
+        "Must be a valid URL (e.g. https://instagram.com/you)";
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setLoading(true);
+    setServerError(null);
+
+    try {
+      const res = await fetch(`${API_URL}/api/v1/user/onboarding`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          username: form.username,
+          xUrl: form.xUrl || undefined,
+          linkedinUrl: form.linkedinUrl || undefined,
+          instagramUrl: form.instagramUrl || undefined,
+        }),
+      });
+
+      const data = await res.json();
+
+      if (res.status === 409) {
+        setErrors({ username: "This username is already taken" });
+        return;
+      }
+
+      if (!res.ok) {
+        setServerError(data.message ?? "Something went wrong. Please try again.");
+        return;
+      }
+
+      // Success — go to dashboard
+      router.push("/dashboard");
+    } catch {
+      setServerError("Network error. Please check your connection.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-primary text-primary-foreground text-xl font-bold mb-4">
+            S
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Set up your profile
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Just a few things to get you started
+          </p>
+        </div>
+
+        <Card>
+          <form onSubmit={handleSubmit} noValidate>
+            <CardHeader>
+              <CardTitle className="text-base">Your details</CardTitle>
+              <CardDescription>
+                Choose a unique username and optionally add your social links.
+              </CardDescription>
+            </CardHeader>
+
+            <CardContent className="space-y-5">
+              {/* Username */}
+              <div className="space-y-1.5">
+                <Label htmlFor="username">Username</Label>
+                <div className="flex">
+                  <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-input bg-muted text-muted-foreground text-sm">
+                    @
+                  </span>
+                  <Input
+                    id="username"
+                    name="username"
+                    type="text"
+                    placeholder="yourhandle"
+                    value={form.username}
+                    onChange={handleChange}
+                    className="rounded-l-none"
+                    autoComplete="off"
+                    autoCapitalize="none"
+                  />
+                </div>
+                {errors.username && (
+                  <p className="text-destructive text-xs">{errors.username}</p>
+                )}
+              </div>
+
+              {/* Divider */}
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <span className="w-full border-t border-border" />
+                </div>
+                <div className="relative flex justify-center">
+                  <span className="bg-card px-2 text-xs text-muted-foreground">
+                    Social links (optional)
+                  </span>
+                </div>
+              </div>
+
+              {/* X */}
+              <div className="space-y-1.5">
+                <Label htmlFor="xUrl" className="flex items-center gap-1.5">
+                  <XIcon />
+                  X (Twitter)
+                </Label>
+                <Input
+                  id="xUrl"
+                  name="xUrl"
+                  type="url"
+                  placeholder="https://x.com/yourhandle"
+                  value={form.xUrl}
+                  onChange={handleChange}
+                />
+                {errors.xUrl && (
+                  <p className="text-destructive text-xs">{errors.xUrl}</p>
+                )}
+              </div>
+
+              {/* LinkedIn */}
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="linkedinUrl"
+                  className="flex items-center gap-1.5"
+                >
+                  <LinkedInIcon />
+                  LinkedIn
+                </Label>
+                <Input
+                  id="linkedinUrl"
+                  name="linkedinUrl"
+                  type="url"
+                  placeholder="https://linkedin.com/in/yourname"
+                  value={form.linkedinUrl}
+                  onChange={handleChange}
+                />
+                {errors.linkedinUrl && (
+                  <p className="text-destructive text-xs">
+                    {errors.linkedinUrl}
+                  </p>
+                )}
+              </div>
+
+              {/* Instagram */}
+              <div className="space-y-1.5">
+                <Label
+                  htmlFor="instagramUrl"
+                  className="flex items-center gap-1.5"
+                >
+                  <InstagramIcon />
+                  Instagram
+                </Label>
+                <Input
+                  id="instagramUrl"
+                  name="instagramUrl"
+                  type="url"
+                  placeholder="https://instagram.com/yourhandle"
+                  value={form.instagramUrl}
+                  onChange={handleChange}
+                />
+                {errors.instagramUrl && (
+                  <p className="text-destructive text-xs">
+                    {errors.instagramUrl}
+                  </p>
+                )}
+              </div>
+
+              {/* Server error */}
+              {serverError && (
+                <p className="text-destructive text-sm bg-destructive/10 rounded-md px-3 py-2">
+                  {serverError}
+                </p>
+              )}
+            </CardContent>
+
+            <CardFooter>
+              <Button
+                id="onboarding-submit"
+                type="submit"
+                className="w-full"
+                disabled={loading}
+              >
+                {loading ? "Saving…" : "Continue to dashboard →"}
+              </Button>
+            </CardFooter>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -43,20 +43,25 @@ function InstagramIcon() {
 
 type FormState = {
   username: string;
-  xUrl: string;
-  linkedinUrl: string;
-  instagramUrl: string;
+  socialLinks: {
+    x: string;
+    linkedin: string;
+    instagram: string;
+  };
 };
 
-type FieldError = Partial<Record<keyof FormState, string>>;
+type FieldError = {
+  username?: string;
+  x?: string;
+  linkedin?: string;
+  instagram?: string;
+};
 
 export default function OnboardingPage() {
   const router = useRouter();
   const [form, setForm] = useState<FormState>({
     username: "",
-    xUrl: "",
-    linkedinUrl: "",
-    instagramUrl: "",
+    socialLinks: { x: "", linkedin: "", instagram: "" },
   });
   const [errors, setErrors] = useState<FieldError>({});
   const [serverError, setServerError] = useState<string | null>(null);
@@ -64,9 +69,17 @@ export default function OnboardingPage() {
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const { name, value } = e.target;
-    setForm((prev) => ({ ...prev, [name]: value }));
-    // Clear the error for the field being edited
-    setErrors((prev) => ({ ...prev, [name]: undefined }));
+    if (name === "username") {
+      setForm((prev) => ({ ...prev, username: value }));
+      setErrors((prev) => ({ ...prev, username: undefined }));
+    } else {
+      // name is one of: x | linkedin | instagram
+      setForm((prev) => ({
+        ...prev,
+        socialLinks: { ...prev.socialLinks, [name]: value },
+      }));
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
     setServerError(null);
   }
 
@@ -79,14 +92,12 @@ export default function OnboardingPage() {
         "3–30 chars, lowercase letters, numbers, underscores only";
     }
     const urlPattern = /^https?:\/\/.+/;
-    if (form.xUrl && !urlPattern.test(form.xUrl))
-      next.xUrl = "Must be a valid URL (e.g. https://x.com/you)";
-    if (form.linkedinUrl && !urlPattern.test(form.linkedinUrl))
-      next.linkedinUrl =
-        "Must be a valid URL (e.g. https://linkedin.com/in/you)";
-    if (form.instagramUrl && !urlPattern.test(form.instagramUrl))
-      next.instagramUrl =
-        "Must be a valid URL (e.g. https://instagram.com/you)";
+    if (form.socialLinks.x && !urlPattern.test(form.socialLinks.x))
+      next.x = "Must be a valid URL (e.g. https://x.com/you)";
+    if (form.socialLinks.linkedin && !urlPattern.test(form.socialLinks.linkedin))
+      next.linkedin = "Must be a valid URL (e.g. https://linkedin.com/in/you)";
+    if (form.socialLinks.instagram && !urlPattern.test(form.socialLinks.instagram))
+      next.instagram = "Must be a valid URL (e.g. https://instagram.com/you)";
 
     setErrors(next);
     return Object.keys(next).length === 0;
@@ -106,9 +117,11 @@ export default function OnboardingPage() {
         credentials: "include",
         body: JSON.stringify({
           username: form.username,
-          xUrl: form.xUrl || undefined,
-          linkedinUrl: form.linkedinUrl || undefined,
-          instagramUrl: form.instagramUrl || undefined,
+          socialLinks: {
+            x: form.socialLinks.x || undefined,
+            linkedin: form.socialLinks.linkedin || undefined,
+            instagram: form.socialLinks.instagram || undefined,
+          },
         }),
       });
 
@@ -124,7 +137,8 @@ export default function OnboardingPage() {
         return;
       }
 
-      // Success — go to dashboard
+      // Success — mark onboarding complete in a cookie so middleware can read it
+      document.cookie = "snap_onboarded=1; path=/; max-age=31536000; SameSite=Lax";
       router.push("/dashboard");
     } catch {
       setServerError("Network error. Please check your connection.");
@@ -203,14 +217,14 @@ export default function OnboardingPage() {
                 </Label>
                 <Input
                   id="xUrl"
-                  name="xUrl"
+                  name="x"
                   type="url"
                   placeholder="https://x.com/yourhandle"
-                  value={form.xUrl}
+                  value={form.socialLinks.x}
                   onChange={handleChange}
                 />
-                {errors.xUrl && (
-                  <p className="text-destructive text-xs">{errors.xUrl}</p>
+                {errors.x && (
+                  <p className="text-destructive text-xs">{errors.x}</p>
                 )}
               </div>
 
@@ -225,15 +239,15 @@ export default function OnboardingPage() {
                 </Label>
                 <Input
                   id="linkedinUrl"
-                  name="linkedinUrl"
+                  name="linkedin"
                   type="url"
                   placeholder="https://linkedin.com/in/yourname"
-                  value={form.linkedinUrl}
+                  value={form.socialLinks.linkedin}
                   onChange={handleChange}
                 />
-                {errors.linkedinUrl && (
+                {errors.linkedin && (
                   <p className="text-destructive text-xs">
-                    {errors.linkedinUrl}
+                    {errors.linkedin}
                   </p>
                 )}
               </div>
@@ -249,15 +263,15 @@ export default function OnboardingPage() {
                 </Label>
                 <Input
                   id="instagramUrl"
-                  name="instagramUrl"
+                  name="instagram"
                   type="url"
                   placeholder="https://instagram.com/yourhandle"
-                  value={form.instagramUrl}
+                  value={form.socialLinks.instagram}
                   onChange={handleChange}
                 />
-                {errors.instagramUrl && (
+                {errors.instagram && (
                   <p className="text-destructive text-xs">
-                    {errors.instagramUrl}
+                    {errors.instagram}
                   </p>
                 )}
               </div>

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -125,7 +125,7 @@ export default function OnboardingPage() {
         }),
       });
 
-      const data = await res.json();
+      const data = await res.json().catch(() => ({}));
 
       if (res.status === 409) {
         setErrors({ username: "This username is already taken" });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,7 +7,10 @@ const ONBOARDING_ONLY = ["/onboarding"];
 export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
-  const sessionToken = req.cookies.get("better-auth.session_token")?.value;
+  // BetterAuth uses a plain name in HTTP (dev) and __Secure- prefix in HTTPS (prod)
+  const sessionToken =
+    req.cookies.get("better-auth.session_token")?.value ??
+    req.cookies.get("__Secure-better-auth.session_token")?.value;
   const isLoggedIn = Boolean(sessionToken);
 
   const isOnboarded = req.cookies.get("snap_onboarded")?.value === "1";

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const PROTECTED = ["/dashboard"];
+
+const ONBOARDING_ONLY = ["/onboarding"];
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  const sessionToken = req.cookies.get("better-auth.session_token")?.value;
+  const isLoggedIn = Boolean(sessionToken);
+
+  const isOnboarded = req.cookies.get("snap_onboarded")?.value === "1";
+
+
+  if (ONBOARDING_ONLY.some((p) => pathname.startsWith(p))) {
+    if (isLoggedIn && isOnboarded) {
+      return NextResponse.redirect(new URL("/dashboard", req.url));
+    }
+    return NextResponse.next();
+  }
+
+
+  if (PROTECTED.some((p) => pathname.startsWith(p))) {
+
+    if (!isLoggedIn) {
+      return NextResponse.redirect(new URL("/login", req.url));
+    }
+    if (!isOnboarded) {
+      return NextResponse.redirect(new URL("/onboarding", req.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api).*)"],
+};

--- a/packages/db/prisma/migrations/20260630074754_add_onboarding_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260630074754_add_onboarding_fields/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "instagramUrl" TEXT,
+ADD COLUMN     "linkedinUrl" TEXT,
+ADD COLUMN     "onboardingCompleted" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "xUrl" TEXT;

--- a/packages/db/prisma/migrations/20260630082436_refactor_social_links_to_json/migration.sql
+++ b/packages/db/prisma/migrations/20260630082436_refactor_social_links_to_json/migration.sql
@@ -1,0 +1,13 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `instagramUrl` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `linkedinUrl` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `xUrl` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "instagramUrl",
+DROP COLUMN "linkedinUrl",
+DROP COLUMN "xUrl",
+ADD COLUMN     "socialLinks" JSONB NOT NULL DEFAULT '{}';

--- a/packages/db/prisma/schema/user.prisma
+++ b/packages/db/prisma/schema/user.prisma
@@ -32,6 +32,12 @@ model User {
   sessions      Session[]
   accounts      Account[]
 
+  // Onboarding
+  onboardingCompleted Boolean @default(false)
+  xUrl                String?
+  linkedinUrl         String?
+  instagramUrl        String?
+
   // Metadata
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt

--- a/packages/db/prisma/schema/user.prisma
+++ b/packages/db/prisma/schema/user.prisma
@@ -34,9 +34,7 @@ model User {
 
   // Onboarding
   onboardingCompleted Boolean @default(false)
-  xUrl                String?
-  linkedinUrl         String?
-  instagramUrl        String?
+  socialLinks         Json    @default("{}")
 
   // Metadata
   createdAt     DateTime  @default(now())

--- a/test-onboarding.md
+++ b/test-onboarding.md
@@ -1,0 +1,196 @@
+# Onboarding Flow — Test Guide
+
+Complete end-to-end steps to spin up the stack and test the `/onboarding` feature from scratch.
+
+---
+
+## Prerequisites
+
+- Docker installed and running
+- `bun` installed (`bun --version`)
+- Repo cloned and dependencies installed
+
+---
+
+## Step 1 — Start the Database (Docker)
+
+The project uses a local Postgres container named `snapform-postgres-new`.
+
+```bash
+docker start snapform-postgres-new
+```
+
+**Verify it's running:**
+
+```bash
+docker ps | grep snapform-postgres-new
+```
+
+You should see `Up X seconds` in the status column.
+
+> **If the container doesn't exist yet**, create it:
+> ```bash
+> docker run --name snapform-postgres-new \
+>   -e POSTGRES_USER=postgres \
+>   -e POSTGRES_PASSWORD=postgres \
+>   -e POSTGRES_DB=snapform \
+>   -p 5432:5432 \
+>   -d postgres:16-alpine
+> ```
+
+---
+
+## Step 2 — Apply Database Migrations
+
+Run from the `packages/db` directory. This applies all migrations including `add_onboarding_fields`.
+
+```bash
+cd packages/db
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/snapform?schema=public" \
+  bun --bun run prisma migrate deploy
+cd ../..
+```
+
+> **If you hit a schema drift error** (DB out of sync with migrations), reset the dev DB:
+> ```bash
+> cd packages/db
+> bun --bun run prisma migrate reset --force
+> cd ../..
+> ```
+
+---
+
+## Step 3 — Install Dependencies
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/snapform?schema=public" \
+  bun install
+```
+
+The `DATABASE_URL` env var is needed because `@repo/db`'s postinstall script runs `prisma generate`.
+
+---
+
+## Step 4 — Start the Dev Servers
+
+From the monorepo root:
+
+```bash
+bun run dev
+```
+
+This starts all apps via Turborepo:
+
+| App | URL |
+|---|---|
+| **API** (Express) | `http://localhost:3000` |
+| **Web** (Next.js) | `http://localhost:3001` |
+
+Expected output:
+```
+api:dev: Express API running on port 3000
+web:dev: ▲ Next.js 16.2.9 (Turbopack)
+web:dev: - Local: http://localhost:3001
+```
+
+> The API uses `bun --watch`, so any changes to API source files will auto-reload without restarting.
+
+---
+
+## Step 5 — Create a Test User (Register)
+
+Run this in your terminal:
+
+```bash
+curl -X POST http://localhost:3000/api/v1/auth/manual/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@test.com","password":"password123","name":"Test User"}'
+```
+
+**Expected response:**
+```json
+{
+  "token": "...",
+  "user": {
+    "name": "Test User",
+    "email": "test@test.com",
+    "emailVerified": false,
+    "username": null,
+    "id": "..."
+  }
+}
+```
+
+---
+
+## Step 6 — Log In from the Browser (to set the session cookie)
+
+Open **`http://localhost:3001/onboarding`** in your browser, then paste this in the **DevTools Console** (`F12` → Console tab):
+
+```js
+await fetch("http://localhost:3000/api/v1/auth/manual/login", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  credentials: "include",
+  body: JSON.stringify({ email: "test@test.com", password: "password123" })
+}).then(r => r.json()).then(console.log)
+```
+
+You should see the user object logged. The session cookie is now set on `localhost:3001`.
+
+---
+
+## Step 7 — Test the Onboarding Form
+
+Navigate to **`http://localhost:3001/onboarding`**.
+
+### ✅ Happy path
+
+| Field | Value |
+|---|---|
+| Username | `testuser` |
+| X (Twitter) | `https://x.com/testuser` *(optional)* |
+| LinkedIn | `https://linkedin.com/in/testuser` *(optional)* |
+| Instagram | `https://instagram.com/testuser` *(optional)* |
+
+Click **Continue to dashboard →**
+
+**Expected:** Redirects to `/dashboard` (page may be empty — that's fine, the redirect means success). Check the network tab for a `200` response from `/api/v1/user/onboarding`.
+
+---
+
+### ❌ Error cases to verify
+
+| Scenario | Expected behaviour |
+|---|---|
+| Empty username | Red inline error: *"Username is required"* |
+| Username too short (e.g. `ab`) | Error: *"3–30 chars, lowercase letters, numbers, underscores only"* |
+| Username with uppercase/spaces | Same format error |
+| Invalid URL in a social field | Red inline error: *"Must be a valid URL"* |
+| Duplicate username (same name, different account) | `409` from API, error shown: *"This username is already taken"* |
+
+---
+
+## Step 8 — Verify in the Database
+
+```bash
+cd packages/db
+bun --bun run prisma studio
+```
+
+This opens Prisma Studio at `http://localhost:5555`. Navigate to the **users** table and confirm:
+- `username` is set
+- `onboardingCompleted` is `true`
+- Social URL fields are populated (or `null` if left blank)
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `Can't reach database server at localhost:5432` | `docker start snapform-postgres-new` |
+| `Cannot find module '.prisma/client/default'` | `cp -r node_modules/.bun/@prisma+client@*/node_modules/.prisma node_modules/.prisma` |
+| `401 Unauthorized` on form submit | You're not logged in — redo Step 6 |
+| `Network error` on form submit | CORS issue — make sure the API restarted after `app.ts` changes |
+| Port 3000 already in use | Kill old process: `lsof -ti:3000 \| xargs kill` |


### PR DESCRIPTION
## Summary

Implements the new user onboarding flow. After signing up, users are directed to `/onboarding` to pick a unique username and optionally add their X, LinkedIn, and Instagram profile links. On success they land on `/dashboard`. Route guards via Next.js middleware prevent unauthenticated access and skip already-onboarded users past the onboarding page.

Full name is **not** collected in onboarding — it already comes from OAuth into the existing `name` field.

Closes #32 
---

## Changes

### Database — `packages/db`

**`user.prisma`** — 2 new fields added to `User`:

| Field | Type | Default | Purpose |
|---|---|---|---|
| `onboardingCompleted` | `Boolean` | `false` | Guards routes, tracks flow state |
| `socialLinks` | `Json` | `{}` | Stores `{ x, linkedin, instagram }` as a single key-value object |

**Migrations created:**
- `20260630074754_add_onboarding_fields`
- `20260630082436_refactor_social_links_to_json`

> Social links were initially implemented as three separate string columns (`xUrl`, `linkedinUrl`, `instagramUrl`) and later refactored into a single `Json` column per reviewer feedback.

---

### Backend — `apps/api`

**`src/lib/user-schemas.ts`** *(new)*  
Zod validation schema for the onboarding endpoint:
- `username` — required, 3–30 chars, `/^[a-z0-9_]+$/`
- `socialLinks.x`, `socialLinks.linkedin`, `socialLinks.instagram` — all optional valid URLs

**`src/controllers/onboarding.controller.ts`** *(new)*  
`POST /api/v1/user/onboarding` handler:
1. Validates body with `OnboardingSchema`
2. Checks username uniqueness against other users — `409` if taken
3. Writes `username`, `socialLinks`, `onboardingCompleted: true` to DB

**`src/routes/user/onboarding.routes.ts`** *(new)*  
Single route: `POST /`, protected by `requireAuth` middleware.

**`src/routes/index.ts`** *(modified)*  
Registered at `POST /api/v1/user/onboarding`.

**`src/app.ts`** *(modified)*  
Fixed CORS — replaced `cors()` (wildcard `*`) with:
```ts
cors({ origin: process.env.FRONTEND_URL, credentials: true })
```
Without this, credentialed `fetch` requests from the browser are silently blocked.

**`package.json`** *(modified)*  
Added `--watch` to the `dev` script so the API auto-reloads on file changes:
```
"dev": "bun --watch run src/index.ts"
```

---

### Frontend — `apps/web`

**`src/middleware.ts`** *(new)*  
Next.js edge middleware that runs before every page render. Uses two cookies with no API call:

| Cookie | Set by | Meaning |
|---|---|---|
| `better-auth.session_token` | BetterAuth | User is logged in |
| `snap_onboarded` | Onboarding page (on success) | User has completed onboarding |

Rules enforced:

| Route | Not logged in | Logged in, not onboarded | Logged in, onboarded |
|---|---|---|---|
| `/onboarding` | allow | allow | → `/dashboard` |
| `/dashboard` | → `/login` | → `/onboarding` | allow |

**`src/app/onboarding/page.tsx`** *(new)*  
Client component onboarding form:
- `@username` input with format validation
- X, LinkedIn, Instagram URL inputs (all optional)
- Inline field errors + username conflict message (409)
- On success: sets `snap_onboarded=1` cookie, redirects to `/dashboard`

**`src/app/dashboard/page.tsx`** *(new)*  
Minimal placeholder dashboard — animated checkmark, stat card placeholders, "under construction" notice.

---

## API Reference

### `POST /api/v1/user/onboarding`

**Auth required:** Yes (BetterAuth session cookie)

**Request body:**
```json
{
  "username": "myhandle",
  "socialLinks": {
    "x": "https://x.com/myhandle",
    "linkedin": "https://linkedin.com/in/myname",
    "instagram": "https://instagram.com/myhandle"
  }
}
```

**Responses:**

| Status | Reason |
|---|---|
| `200` | Onboarding saved |
| `400` | Validation error |
| `401` | Not authenticated |
| `409` | Username already taken |

---

##  Deployment Steps Required

**1. Run migrations on the production (Neon) database:**
```bash
cd packages/db && bun --bun run prisma migrate deploy
```
Adds `onboardingCompleted` and `socialLinks` to the `users` table. Deploying without this will cause Prisma runtime errors.

**2. Set environment variables:**

| App | Variable | Value |
|---|---|---|
| `apps/api` | `FRONTEND_URL` | Production frontend URL (e.g. `https://app.snapform.com`) |
| `apps/web` | `NEXT_PUBLIC_API_URL` | Production API URL (e.g. `https://api.snapform.com`) |

---

## Known Limitations

- **`/login` page does not exist yet** — the middleware redirects unauthenticated users to `/login`, which currently 404s. A login page is a follow-up task.
- **`snap_onboarded` cookie is client-set** — it is written by the browser after a successful API response. If a user's `onboardingCompleted` is ever reset server-side, the stale cookie will still let them skip onboarding. Acceptable for now since the flag is write-once.

---

## How to Test

See [`test-onboarding.md`](./test-onboarding.md) for the full step-by-step guide.

**Quick path:**
1. `docker start snapform-postgres-new`
2. `bun run dev` from repo root
3. Register via curl, log in via browser DevTools console
4. Visit `http://localhost:3001/onboarding`, fill the form → lands on `/dashboard`
5. Try visiting `/onboarding` again → redirected back to `/dashboard`
6. Clear all cookies → visiting `/dashboard` redirects to `/login`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added a new post-signup onboarding flow for first-time users.
- New users are now guided to set a unique username and can optionally add X, LinkedIn, and Instagram links.
- Onboarding completion now saves the profile details and marks the account as onboarded.
- Users are redirected to the dashboard after finishing setup.
- Added route protection so onboarded users skip onboarding, while unauthenticated or incomplete users are sent to the right place.
- Updated backend and database support to store onboarding status and social profile data.
- Improved browser API access setup and developer workflow for the API service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->