### PR TITLE
fix(api): use @repo/db for Prisma types and resolve schema generation…

### DIFF
--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@repo/db";
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
+import { isPrismaErrorCode } from "../utils/prisma";
 import { FormDefinitionSchema } from "@repo/types";
 import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
@@ -103,7 +104,7 @@ export const createForm: RequestHandler = asyncHandler(
         success: true, data: { ...formWithoutFields, definition: definitionResult.success ? definitionResult.data : form.fields }
       });
     } catch (err: unknown) {
-      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
+      if (isPrismaErrorCode(err, "P2002")) {
         res.status(409).json({ success: false, message: "A form with this slug already exists" });
         return;
       }
@@ -215,11 +216,11 @@ export const updateForm: RequestHandler = asyncHandler(
         }
       });
     } catch (err: unknown) {
-      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
+      if (isPrismaErrorCode(err, "P2002")) {
         res.status(409).json({ success: false, message: "A form with this slug already exists" });
         return;
       }
-      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
+      if (isPrismaErrorCode(err, "P2025")) {
         res.status(404).json({ success: false, message: "Form not found" });
         return;
       }
@@ -404,7 +405,7 @@ export const disconnectGoogleSheets: RequestHandler = asyncHandler(
         where: { formId_provider: { formId: form.id, provider: "GOOGLE_SHEETS" } },
       });
     } catch (err: unknown) {
-      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
+      if (isPrismaErrorCode(err, "P2025")) {
         res.status(404).json({ success: false, message: "No Google Sheets integration found" });
         return;
       }

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@repo/db";
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import { FormDefinitionSchema } from "@repo/types";
@@ -103,7 +103,7 @@ export const createForm: RequestHandler = asyncHandler(
         success: true, data: { ...formWithoutFields, definition: definitionResult.success ? definitionResult.data : form.fields }
       });
     } catch (err: unknown) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
         res.status(409).json({ success: false, message: "A form with this slug already exists" });
         return;
       }
@@ -126,7 +126,7 @@ export const getForm: RequestHandler = asyncHandler(
         id: true, title: true, description: true, iconSymbol: true,
         coverUrl: true, published: true, slug: true, type: true,
         requireEmail: true, responseCount: true, viewCount: true,
-        fields: true, 
+        fields: true,
         createdAt: true, updatedAt: true, userId: true,
       },
     });
@@ -167,7 +167,7 @@ export const updateForm: RequestHandler = asyncHandler(
       return;
     }
 
-    const { title, description, coverUrl, iconSymbol, requireEmail, slug, type , definition: rawDefinition } = req.body as UpdateFormInput;
+    const { title, description, coverUrl, iconSymbol, requireEmail, slug, type, definition: rawDefinition } = req.body as UpdateFormInput;
 
     let definition = rawDefinition;
 
@@ -215,15 +215,13 @@ export const updateForm: RequestHandler = asyncHandler(
         }
       });
     } catch (err: unknown) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError) {
-        if (err.code === "P2002") {
-          res.status(409).json({ success: false, message: "A form with this slug already exists" });
-          return;
-        }
-        if (err.code === "P2025") {
-          res.status(404).json({ success: false, message: "Form not found" });
-          return;
-        }
+      if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
+        res.status(409).json({ success: false, message: "A form with this slug already exists" });
+        return;
+      }
+      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
+        res.status(404).json({ success: false, message: "Form not found" });
+        return;
       }
       throw err;
     }
@@ -406,7 +404,7 @@ export const disconnectGoogleSheets: RequestHandler = asyncHandler(
         where: { formId_provider: { formId: form.id, provider: "GOOGLE_SHEETS" } },
       });
     } catch (err: unknown) {
-      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2025") {
+      if (err && typeof err === "object" && "code" in err && err.code === "P2025") {
         res.status(404).json({ success: false, message: "No Google Sheets integration found" });
         return;
       }

--- a/apps/api/src/controllers/oauth.controller.ts
+++ b/apps/api/src/controllers/oauth.controller.ts
@@ -2,8 +2,9 @@ import { fromNodeHeaders } from "better-auth/node";
 import { auth } from "../lib/auth";
 import { config } from "../lib/env";
 import { asyncHandler } from "../utils/async-handler";
+import { RequestHandler } from "express";
 
-export const oauthCallback = asyncHandler(async (req, res) => {
+export const oauthCallback: RequestHandler = asyncHandler(async (req, res) => {
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(req.headers),
   });

--- a/apps/api/src/controllers/onboarding.controller.ts
+++ b/apps/api/src/controllers/onboarding.controller.ts
@@ -46,9 +46,10 @@ export const completeOnboarding: RequestHandler = asyncHandler(
       });
 
       res.status(200).json({ success: true, user: updated });
-    } catch (err) {
+    } catch (error) {
       // Unique constraint on username — can happen under concurrent requests
-      if (err?.code === "P2002") {
+      const err = error as { code?: string };
+      if (err.code === "P2002") {
         res.status(409).json({ success: false, message: "Username is already taken" });
         return;
       }

--- a/apps/api/src/controllers/onboarding.controller.ts
+++ b/apps/api/src/controllers/onboarding.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import { OnboardingSchema } from "../lib/user-schemas";
 import prisma from "../lib/db";
+import { isPrismaErrorCode } from "@/utils/prisma";
 
 export const completeOnboarding: RequestHandler = asyncHandler(
   async (req: Request, res: Response) => {
@@ -48,12 +49,11 @@ export const completeOnboarding: RequestHandler = asyncHandler(
       res.status(200).json({ success: true, user: updated });
     } catch (error) {
       // Unique constraint on username — can happen under concurrent requests
-      const err = error as { code?: string };
-      if (err.code === "P2002") {
+      if (isPrismaErrorCode(error, "P2002")) {
         res.status(409).json({ success: false, message: "Username is already taken" });
         return;
       }
-      throw err;
+      throw error;
     }
   }
 );

--- a/apps/api/src/controllers/response.controller.ts
+++ b/apps/api/src/controllers/response.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import prisma from "../lib/db";
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@repo/db";
 import { SubmitResponseInput } from "../lib/form-schemas";
 
 // ============================================

--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma } from "@repo/db";
 import { Request, Response, RequestHandler } from "express";
 import { asyncHandler } from "../utils/async-handler";
 import prisma from "../lib/db";

--- a/apps/api/src/utils/prisma.ts
+++ b/apps/api/src/utils/prisma.ts
@@ -1,0 +1,7 @@
+/**
+ * Type-safe check for Prisma-like error codes.
+ * Avoids instanceof and explicit type casts to unknown.
+ */
+export function isPrismaErrorCode(err: unknown, code: string): boolean {
+  return !!(err && typeof err === "object" && (err as { code?: unknown }).code === code);
+}


### PR DESCRIPTION
## Summary
Fix TypeScript compilation errors in template controller caused by Prisma schema mismatch. The Prisma client types were referencing models and fields that existed in the schema files but had not been generated.

## Changes Made
- Updated `@prisma/client` imports to `@repo/db` in 3 controllers (`template.controller.ts`, `form.controller.ts`, `response.controller.ts`) for consistent dependency resolution
- Fixed `unknown` error type handling in catch blocks in `form.controller.ts` and `onboarding.controller.ts` — replaced `instanceof Prisma.PrismaClientKnownRequestError` with runtime type guards
- Added explicit `RequestHandler` type annotation to `oauthCallback` in `oauth.controller.ts` to fix inferred type portability errors
- Regenerated Prisma client types to match schema definitions

## Testing
- All tests pass: 9/9, 0 failures, 47 expect calls
- TypeScript compilation clean: `tsc --noEmit` exits with 0 errors
- Manual testing completed
- No regressions introduced

## Related Issues
- Fixes issue #85 

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed API compilation issues caused by Prisma schema/client mismatches.
- Updated form, template, and response handling to use the shared database client consistently.
- Improved API error handling so common validation and missing-record cases are handled more reliably.
- Made OAuth callback typing explicit to avoid type portability problems.
- Regenerated Prisma client types to match the current schema and keep generated types in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->