### PR TITLE
test: add integration tests for dashboard routes

### DIFF
--- a/packages/api-tests/integration-tests/modules/dashboard.test.ts
+++ b/packages/api-tests/integration-tests/modules/dashboard.test.ts
@@ -12,7 +12,7 @@ describe("Dashboard API Routes", () => {
   describe("Test 1: Form pagination (GET /api/v1/forms?page=1&limit=3)", () => {
     it("should return paginated forms with correct metadata", async () => {
       const { client, user } = await createAuthenticatedClient();
-      
+
       // Setup: Seed 5 forms directly using Prisma
       for (let i = 1; i <= 5; i++) {
         await prisma.form.create({
@@ -26,7 +26,7 @@ describe("Dashboard API Routes", () => {
 
       // Act
       const response = await client.get("/api/v1/forms?page=1&limit=3");
-      
+
       // Assert
       expect(response.status).toBe(200);
       expect(response.data.data.length).toBe(3);
@@ -40,8 +40,10 @@ describe("Dashboard API Routes", () => {
   describe("Test 2: Template ownership filtering (GET /api/v1/templates/owned)", () => {
     it("should return only templates owned by the authenticated user", async () => {
       // Setup: Create two users
-      const userA = await createAuthenticatedClient({ email: "userA@example.com" });
-      const userB = await createAuthenticatedClient({ email: "userB@example.com" });
+      const userA = await createAuthenticatedClient({ email: `userA-${crypto.randomUUID()}@test.com` });
+      const userB = await createAuthenticatedClient({ email: `userB-${crypto.randomUUID()}@test.com` });
+
+      const userATitles = ["User A Template 1", "User A Template 2"];
 
       // Seed 2 templates for User A
       for (let i = 1; i <= 2; i++) {
@@ -67,11 +69,14 @@ describe("Dashboard API Routes", () => {
 
       // Act: User A fetches owned templates
       const response = await userA.client.get("/api/v1/templates/owned");
-      
+
       // Assert
-      expect(response.status).toBe(200);
+      // Verify that only user A's 2 templates are returned
       expect(response.data.data.length).toBe(2);
-      
+      response.data.data.forEach((t: any) => {
+        expect(userATitles).toContain(t.title);
+      });
+
       // Verify all 4 exist in DB total
       const totalTemplates = await prisma.template.count();
       expect(totalTemplates).toBe(4);

--- a/packages/api-tests/integration-tests/modules/dashboard.test.ts
+++ b/packages/api-tests/integration-tests/modules/dashboard.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="bun-types" />
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createAuthenticatedClient } from "../setup/auth";
+import { cleanDb } from "../setup/db";
+import { prisma } from "@repo/db";
+
+describe("Dashboard API Routes", () => {
+  beforeEach(async () => {
+    await cleanDb();
+  });
+
+  describe("Test 1: Form pagination (GET /api/v1/forms?page=1&limit=3)", () => {
+    it("should return paginated forms with correct metadata", async () => {
+      const { client, user } = await createAuthenticatedClient();
+      
+      // Setup: Seed 5 forms directly using Prisma
+      for (let i = 1; i <= 5; i++) {
+        await prisma.form.create({
+          data: {
+            title: `Form ${i}`,
+            slug: `form-pagination-${user.id}-${i}`,
+            userId: user.id,
+          },
+        });
+      }
+
+      // Act
+      const response = await client.get("/api/v1/forms?page=1&limit=3");
+      
+      // Assert
+      expect(response.status).toBe(200);
+      expect(response.data.data.length).toBe(3);
+      expect(response.data.meta.total).toBe(5);
+      expect(response.data.meta.page).toBe(1);
+      expect(response.data.meta.limit).toBe(3);
+      expect(response.data.meta.totalPages).toBe(2);
+    });
+  });
+
+  describe("Test 2: Template ownership filtering (GET /api/v1/templates/owned)", () => {
+    it("should return only templates owned by the authenticated user", async () => {
+      // Setup: Create two users
+      const userA = await createAuthenticatedClient({ email: "userA@example.com" });
+      const userB = await createAuthenticatedClient({ email: "userB@example.com" });
+
+      // Seed 2 templates for User A
+      for (let i = 1; i <= 2; i++) {
+        await prisma.template.create({
+          data: {
+            title: `User A Template ${i}`,
+            userId: userA.user.id,
+            isPublic: false,
+          },
+        });
+      }
+
+      // Seed 2 templates for User B
+      for (let i = 1; i <= 2; i++) {
+        await prisma.template.create({
+          data: {
+            title: `User B Template ${i}`,
+            userId: userB.user.id,
+            isPublic: false,
+          },
+        });
+      }
+
+      // Act: User A fetches owned templates
+      const response = await userA.client.get("/api/v1/templates/owned");
+      
+      // Assert
+      expect(response.status).toBe(200);
+      expect(response.data.data.length).toBe(2);
+      
+      // Verify all 4 exist in DB total
+      const totalTemplates = await prisma.template.count();
+      expect(totalTemplates).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds full integration test coverage for the Dashboard API routes, verifying form pagination and template ownership filtering.

## Changes Made
- Added `dashboard.test.ts` to `packages/api-tests/integration-tests/modules/`
- Implemented test for `GET /api/v1/forms?page=1&limit=3` to verify pagination metadata
- Implemented test for `GET /api/v1/templates/owned` to verify strict user ownership filtering
- Used standard `createAuthenticatedClient` and `cleanDb` patterns

## Testing
- All tests pass (11 passing across 5 files)
- Integration testing completed locally via `bun test`
- No regressions introduced

## Related Issues
- Fixes Issue #52 

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [ ] Documentation updated
- [x] No linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added dashboard API integration coverage to reduce risk of regressions in core user-facing routes.
- Verified form listing behaves correctly with pagination, including returned page size and metadata.
- Verified owned templates are strictly filtered to the signed-in user, preventing cross-user visibility.
- Expanded confidence in the dashboard experience with end-to-end tests around common API responses and ownership rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->