### PR TITLE
test: add integration tests for SCROLL form creation and partial JSON…

### DIFF
--- a/packages/api-tests/integration-tests/modules/form.test.ts
+++ b/packages/api-tests/integration-tests/modules/form.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { createAuthenticatedClient, createAnonymousClient } from "../setup/auth";
 import { cleanDb } from "../setup/db";
 import { prisma } from "@repo/db";
-import crypto from "crypto";
+import { randomUUID } from "crypto";
 
 describe("Forms API", () => {
   beforeEach(async () => {
@@ -88,8 +88,8 @@ describe("Forms API", () => {
     it("should safely update the JSON definition via PATCH without wiping out other fields", async () => {
       const { client } = await createAuthenticatedClient();
       
-      const q1Id = crypto.randomUUID();
-      const q2Id = crypto.randomUUID();
+      const q1Id = randomUUID();
+      const q2Id = randomUUID();
 
       // 1. Create initial form
       const createResponse = await client.post("/api/v1/forms", {
@@ -120,9 +120,10 @@ describe("Forms API", () => {
         where: { id: formId },
       });
       
-      expect(dbForm?.title).toBe("Initial Form");
-      const dbDefinition = dbForm?.fields as any;
-      expect(dbDefinition.elements[0].id).toBe(q2Id);
+      expect(dbForm).not.toBeNull();
+      expect(dbForm!.title).toBe("Initial Form");
+      const dbDefinition = dbForm!.fields as { elements?: Array<{ id: string }> };
+      expect(dbDefinition.elements?.[0]?.id).toBe(q2Id);
     });
 
     it("should return only forms owned by the authenticated user", async () => {

--- a/packages/api-tests/integration-tests/modules/form.test.ts
+++ b/packages/api-tests/integration-tests/modules/form.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { createAuthenticatedClient, createAnonymousClient } from "../setup/auth";
 import { cleanDb } from "../setup/db";
 import { prisma } from "@repo/db";
+import crypto from "crypto";
 
 describe("Forms API", () => {
   beforeEach(async () => {
@@ -61,6 +62,67 @@ describe("Forms API", () => {
       expect(response.status).toBe(400);
       expect(response.data.success).toBe(false);
       expect(response.data).toHaveProperty("errors");
+    });
+
+    it("should successfully write a new form with FormType.SCROLL into the DB", async () => {
+      const { client } = await createAuthenticatedClient();
+      
+      const response = await client.post("/api/v1/forms", {
+        title: "Scroll Form",
+        description: "A scrolling form",
+        slug: "scroll-form-test",
+        type: "SCROLL"
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data.data.type).toBe("SCROLL");
+
+      // Verify it actually got stored in the DB
+      const dbForm = await prisma.form.findUnique({
+        where: { id: response.data.data.id },
+      });
+      expect(dbForm).not.toBeNull();
+      expect(dbForm?.type).toBe("SCROLL");
+    });
+
+    it("should safely update the JSON definition via PATCH without wiping out other fields", async () => {
+      const { client } = await createAuthenticatedClient();
+      
+      const q1Id = crypto.randomUUID();
+      const q2Id = crypto.randomUUID();
+
+      // 1. Create initial form
+      const createResponse = await client.post("/api/v1/forms", {
+        title: "Initial Form",
+        slug: "patch-test-form",
+        definition: {
+          version: "1.0",
+          elements: [{ id: q1Id, type: "textInput", label: "Initial Question" }]
+        }
+      });
+      expect(createResponse.status).toBe(201);
+      const formId = createResponse.data.data.id;
+
+      // 2. Patch only the definition
+      const patchResponse = await client.patch(`/api/v1/forms/${formId}`, {
+        definition: {
+          version: "1.0",
+          elements: [{ id: q2Id, type: "email", label: "Updated Email Question" }]
+        }
+      });
+      
+      expect(patchResponse.status).toBe(200);
+      expect(patchResponse.data.data.title).toBe("Initial Form"); // Title shouldn't be wiped
+      expect(patchResponse.data.data.definition.elements[0].id).toBe(q2Id); // Definition should be updated
+
+      // Verify in DB
+      const dbForm = await prisma.form.findUnique({
+        where: { id: formId },
+      });
+      
+      expect(dbForm?.title).toBe("Initial Form");
+      const dbDefinition = dbForm?.fields as any;
+      expect(dbDefinition.elements[0].id).toBe(q2Id);
     });
 
     it("should return only forms owned by the authenticated user", async () => {


### PR DESCRIPTION
# Test: Form Editor & Creation Integration Tests

## Description
Closes #53 
Added integration tests for the "Create Form" and "Edit Form" backend routes to ensure the API safely handles complex form definitions.

## Changes Made
- Added a test case verifying `POST /api/v1/forms` successfully writes a new form into the database with the proper `FormType.SCROLL` enum.
- Added a test case verifying `PATCH /api/v1/forms/:id` safely updates the nested JSON definition array without wiping out top-level fields like `title`.
- Used `crypto.randomUUID()` to generate dynamic, Zod-compliant UUIDs for form elements during testing to ensure robust validation.
- All integration tests pass successfully on the local PostgreSQL test database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added coverage for creating forms so a new form is saved correctly with the expected scroll-style form type.
- Added coverage for editing existing forms so updating the form structure does not overwrite other saved details like the title.
- Improved test data generation to use valid unique IDs for form elements.
- These changes help confirm the create/edit form flows behave safely against the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->