### PR TITLE
Test/template community routes

### DIFF
--- a/apps/api/src/controllers/template.controller.ts
+++ b/apps/api/src/controllers/template.controller.ts
@@ -320,6 +320,7 @@ export const purchaseTemplate: RequestHandler = asyncHandler(
                 description: true,
                 fields: true,
                 iconSymbol: true,
+                isPublic: true,
             },
         });
 
@@ -327,6 +328,14 @@ export const purchaseTemplate: RequestHandler = asyncHandler(
             res.status(404).json({
                 success: false,
                 message: "Template not found",
+            });
+            return;
+        }
+
+        if (!template.isPublic) {
+            res.status(403).json({
+                success: false,
+                message: "This template is private and cannot be purchased",
             });
             return;
         }

--- a/packages/api-tests/bunfig.toml
+++ b/packages/api-tests/bunfig.toml
@@ -1,3 +1,2 @@
 [test]
 preload = ["./integration-tests/setup/bootstrap.ts"]
-envFile = "../../.env"

--- a/packages/api-tests/bunfig.toml
+++ b/packages/api-tests/bunfig.toml
@@ -1,2 +1,3 @@
 [test]
 preload = ["./integration-tests/setup/bootstrap.ts"]
+envFile = "../../.env"

--- a/packages/api-tests/integration-tests/modules/template.test.ts
+++ b/packages/api-tests/integration-tests/modules/template.test.ts
@@ -1,0 +1,535 @@
+/// <reference types="bun-types" />
+import { describe, it, expect, beforeEach } from "bun:test";
+import { createAuthenticatedClient, createAnonymousClient } from "../setup/auth";
+import { cleanDb } from "../setup/db";
+import { prisma } from "@repo/db";
+
+// ---------------------------------------------------------------------------
+// Minimal valid fields payload (matches FormDefinitionSchema in @repo/types)
+// ---------------------------------------------------------------------------
+const SAMPLE_FIELDS = {
+  version: "1.0",
+  elements: [
+    {
+      id: "00000000-0000-0000-0000-000000000001",
+      type: "textInput",
+      label: "Name",
+      required: true,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a public community template via the API */
+async function createPublicTemplate(
+  client: Awaited<ReturnType<typeof createAuthenticatedClient>>["client"],
+  overrides: Record<string, unknown> = {},
+) {
+  return client.post("/api/v1/templates", {
+    title: "Sample Community Template",
+    description: "A template for integration tests",
+    category: "HR",
+    price: 0,
+    isPublic: true,
+    fields: SAMPLE_FIELDS,
+    ...overrides,
+  });
+}
+
+// ===========================================================================
+// Test Suite
+// ===========================================================================
+
+describe("Template Community Routes", () => {
+  beforeEach(async () => {
+    await cleanDb();
+  });
+
+  // =========================================================================
+  // Test Case 1 — POST /api/v1/templates
+  // =========================================================================
+
+  describe("POST /api/v1/templates — create a public community template", () => {
+    it("should return 401 when creating a template without authentication", async () => {
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.post("/api/v1/templates", {
+        title: "Anon Template",
+        fields: SAMPLE_FIELDS,
+      });
+
+      expect(response.status).toBe(401);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should return 400 when title is missing", async () => {
+      const { client } = await createAuthenticatedClient();
+      const response = await client.post("/api/v1/templates", {
+        fields: SAMPLE_FIELDS,
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should return 400 when neither formId nor fields are provided", async () => {
+      const { client } = await createAuthenticatedClient();
+      const response = await client.post("/api/v1/templates", {
+        title: "Missing Fields Template",
+      });
+
+      expect(response.status).toBe(400);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should correctly create a public community template with fields", async () => {
+      const { client, user } = await createAuthenticatedClient();
+
+      const response = await createPublicTemplate(client, {
+        title: "Public HR Template",
+        category: "HR",
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data.success).toBe(true);
+
+      const template = response.data.data;
+      expect(template).toHaveProperty("id");
+      expect(template.title).toBe("Public HR Template");
+      expect(template.category).toBe("HR");
+      expect(template.isPublic).toBe(true);
+      expect(template.price).toBe(0);
+      expect(template.userId).toBe(user.id);
+
+      // Verify persistence in DB
+      const dbTemplate = await prisma.template.findUnique({
+        where: { id: template.id },
+      });
+      expect(dbTemplate).not.toBeNull();
+      expect(dbTemplate?.title).toBe("Public HR Template");
+      expect(dbTemplate?.isPublic).toBe(true);
+    });
+
+    it("should snapshot fields from an existing form when formId is provided", async () => {
+      const { client, user } = await createAuthenticatedClient();
+
+      // Create a form first so we have a valid formId
+      const formResponse = await client.post("/api/v1/forms", {
+        title: "Source Form",
+        slug: `source-form-${Date.now()}`,
+      });
+      expect(formResponse.status).toBe(201);
+      const formId = formResponse.data.data.id;
+
+      const response = await client.post("/api/v1/templates", {
+        title: "Snapshot Template",
+        formId,
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.data.success).toBe(true);
+      expect(response.data.data.userId).toBe(user.id);
+    });
+  });
+
+  // =========================================================================
+  // Test Case 2 — GET /api/v1/templates/community
+  // =========================================================================
+
+  describe("GET /api/v1/templates/community — returns public templates with category filtering", () => {
+    it("should be accessible without authentication", async () => {
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.get("/api/v1/templates/community");
+
+      expect(response.status).toBe(200);
+      expect(response.data.success).toBe(true);
+    });
+
+    it("should return only public templates", async () => {
+      const { user } = await createAuthenticatedClient();
+
+      // Seed one public and one private template directly
+      await prisma.template.create({
+        data: {
+          title: "Public Template",
+          isPublic: true,
+          userId: user.id,
+        },
+      });
+      await prisma.template.create({
+        data: {
+          title: "Private Template",
+          isPublic: false,
+          userId: user.id,
+        },
+      });
+
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.get("/api/v1/templates/community");
+
+      expect(response.status).toBe(200);
+      expect(response.data.data.length).toBe(1);
+      expect(response.data.data[0].title).toBe("Public Template");
+      expect(response.data.data[0].isPublic).toBe(true);
+    });
+
+    it("should respect the category filter query parameter", async () => {
+      const { client } = await createAuthenticatedClient();
+
+      // Create templates in two different categories
+      await createPublicTemplate(client, {
+        title: "HR Template",
+        category: "HR",
+      });
+      await createPublicTemplate(client, {
+        title: "Finance Template",
+        category: "Finance",
+      });
+
+      const anonClient = createAnonymousClient();
+      const hrResponse = await anonClient.get(
+        "/api/v1/templates/community?category=HR",
+      );
+
+      expect(hrResponse.status).toBe(200);
+      expect(hrResponse.data.data.length).toBe(1);
+      expect(hrResponse.data.data[0].title).toBe("HR Template");
+      expect(hrResponse.data.data[0].category).toBe("HR");
+    });
+
+    it("should return correct pagination metadata", async () => {
+      const { user } = await createAuthenticatedClient();
+
+      // Seed 5 public templates
+      for (let i = 1; i <= 5; i++) {
+        await prisma.template.create({
+          data: {
+            title: `Template ${i}`,
+            isPublic: true,
+            userId: user.id,
+          },
+        });
+      }
+
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.get(
+        "/api/v1/templates/community?page=1&limit=3",
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.data.data.length).toBe(3);
+      expect(response.data.pagination.total).toBe(5);
+      expect(response.data.pagination.page).toBe(1);
+      expect(response.data.pagination.limit).toBe(3);
+      expect(response.data.pagination.totalPages).toBe(2);
+    });
+
+    it("should include creator details in each community template listing", async () => {
+      const { client } = await createAuthenticatedClient();
+
+      await createPublicTemplate(client, { title: "Template With Creator" });
+
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.get("/api/v1/templates/community");
+
+      expect(response.status).toBe(200);
+      expect(response.data.data.length).toBeGreaterThanOrEqual(1);
+
+      const template = response.data.data[0];
+      expect(template).toHaveProperty("user");
+      expect(template.user).toHaveProperty("id");
+      expect(template.user).toHaveProperty("name");
+    });
+  });
+
+  // =========================================================================
+  // Test Case 3 — POST /api/v1/templates/:id/purchase
+  // =========================================================================
+
+  describe("POST /api/v1/templates/:id/purchase — adds template to UserOwnedTemplate", () => {
+    it("should return 401 when purchasing without authentication", async () => {
+      const { user } = await createAuthenticatedClient();
+
+      // Seed a template to purchase
+      const template = await prisma.template.create({
+        data: { title: "Template To Buy", isPublic: true, userId: user.id },
+      });
+
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.post(
+        `/api/v1/templates/${template.id}/purchase`,
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 404 when purchasing a non-existent template", async () => {
+      const { client } = await createAuthenticatedClient();
+      const response = await client.post(
+        "/api/v1/templates/nonexistent-id/purchase",
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should return 400 when a user tries to purchase their own template", async () => {
+      const { client, user } = await createAuthenticatedClient();
+
+      const template = await prisma.template.create({
+        data: { title: "Own Template", isPublic: true, userId: user.id },
+      });
+
+      const response = await client.post(
+        `/api/v1/templates/${template.id}/purchase`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.data.success).toBe(false);
+      expect(response.data.message).toContain("own template");
+    });
+
+    it("should correctly add the template to the buyer's UserOwnedTemplate list", async () => {
+      // Seller creates a template
+      const seller = await createAuthenticatedClient({
+        email: `seller-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Purchasable Template",
+      });
+      expect(templateRes.status).toBe(201);
+      const templateId = templateRes.data.data.id;
+
+      // Buyer purchases the template
+      const buyer = await createAuthenticatedClient({
+        email: `buyer-${Date.now()}@test.com`,
+      });
+      const purchaseRes = await buyer.client.post(
+        `/api/v1/templates/${templateId}/purchase`,
+      );
+
+      expect(purchaseRes.status).toBe(201);
+      expect(purchaseRes.data.success).toBe(true);
+      expect(purchaseRes.data.data).toHaveProperty("purchase");
+      expect(purchaseRes.data.data).toHaveProperty("clonedForm");
+      expect(purchaseRes.data.data.clonedForm).toHaveProperty("id");
+
+      // Verify a UserOwnedTemplate record was created in the DB
+      const ownership = await prisma.userOwnedTemplate.findUnique({
+        where: {
+          userId_templateId: { userId: buyer.user.id, templateId },
+        },
+      });
+      expect(ownership).not.toBeNull();
+      expect(ownership?.userId).toBe(buyer.user.id);
+      expect(ownership?.templateId).toBe(templateId);
+
+      // Verify the cloned Form exists and is owned by the buyer
+      const clonedForm = await prisma.form.findUnique({
+        where: { id: purchaseRes.data.data.clonedForm.id },
+      });
+      expect(clonedForm).not.toBeNull();
+      expect(clonedForm?.userId).toBe(buyer.user.id);
+      expect(clonedForm?.published).toBe(false);
+    });
+
+    it("should increment the template useCount after purchase", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller2-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "UseCount Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      const buyer = await createAuthenticatedClient({
+        email: `buyer2-${Date.now()}@test.com`,
+      });
+      await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
+
+      const dbTemplate = await prisma.template.findUnique({
+        where: { id: templateId },
+      });
+      expect(dbTemplate?.useCount).toBe(1);
+    });
+
+    it("should return 409 when the same user purchases the same template twice", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller3-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Double Purchase Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      const buyer = await createAuthenticatedClient({
+        email: `buyer3-${Date.now()}@test.com`,
+      });
+
+      // First purchase
+      await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
+
+      // Second purchase — should conflict
+      const response = await buyer.client.post(
+        `/api/v1/templates/${templateId}/purchase`,
+      );
+
+      expect(response.status).toBe(409);
+      expect(response.data.success).toBe(false);
+      expect(response.data.message).toContain("already purchased");
+    });
+  });
+
+  // =========================================================================
+  // Test Case 4 — POST /api/v1/templates/:id/reviews
+  // =========================================================================
+
+  describe("POST /api/v1/templates/:id/reviews — 403 if not purchased", () => {
+    it("should return 401 when leaving a review without authentication", async () => {
+      const { user } = await createAuthenticatedClient();
+
+      const template = await prisma.template.create({
+        data: { title: "Review Target", isPublic: true, userId: user.id },
+      });
+
+      const anonClient = createAnonymousClient();
+      const response = await anonClient.post(
+        `/api/v1/templates/${template.id}/reviews`,
+        { stars: 5 },
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 403 if the user has NOT purchased the template", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller4-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Review Gated Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      // Stranger (never purchased)
+      const stranger = await createAuthenticatedClient({
+        email: `stranger-${Date.now()}@test.com`,
+      });
+      const response = await stranger.client.post(
+        `/api/v1/templates/${templateId}/reviews`,
+        { stars: 4, text: "Great template!" },
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.data.success).toBe(false);
+      expect(response.data.message).toContain("purchase");
+    });
+
+    it("should return 403 when the template creator tries to review their own template", async () => {
+      const { client, user } = await createAuthenticatedClient();
+
+      const template = await prisma.template.create({
+        data: { title: "Creator Self-Review", isPublic: true, userId: user.id },
+      });
+
+      const response = await client.post(
+        `/api/v1/templates/${template.id}/reviews`,
+        { stars: 5, text: "I love my own template" },
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should allow a review only after the user has purchased the template", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller5-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Purchase Before Review Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      // Buyer purchases the template
+      const buyer = await createAuthenticatedClient({
+        email: `buyer5-${Date.now()}@test.com`,
+      });
+      await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
+
+      // Now the buyer leaves a review
+      const reviewRes = await buyer.client.post(
+        `/api/v1/templates/${templateId}/reviews`,
+        { stars: 5, text: "Excellent template!" },
+      );
+
+      expect(reviewRes.status).toBe(201);
+      expect(reviewRes.data.success).toBe(true);
+      expect(reviewRes.data.data.stars).toBe(5);
+      expect(reviewRes.data.data.text).toBe("Excellent template!");
+
+      // Verify review exists in DB
+      const review = await prisma.templateReview.findUnique({
+        where: {
+          templateId_userId: { templateId, userId: buyer.user.id },
+        },
+      });
+      expect(review).not.toBeNull();
+      expect(review?.stars).toBe(5);
+    });
+
+    it("should return 400 when stars is out of range (> 5)", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller6-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Star Validation Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      const buyer = await createAuthenticatedClient({
+        email: `buyer6-${Date.now()}@test.com`,
+      });
+      await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
+
+      const response = await buyer.client.post(
+        `/api/v1/templates/${templateId}/reviews`,
+        { stars: 6 },
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.data.success).toBe(false);
+    });
+
+    it("should return 409 when the user tries to leave a duplicate review", async () => {
+      const seller = await createAuthenticatedClient({
+        email: `seller7-${Date.now()}@test.com`,
+      });
+      const templateRes = await createPublicTemplate(seller.client, {
+        title: "Duplicate Review Template",
+      });
+      const templateId = templateRes.data.data.id;
+
+      const buyer = await createAuthenticatedClient({
+        email: `buyer7-${Date.now()}@test.com`,
+      });
+      await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
+
+      // First review
+      await buyer.client.post(`/api/v1/templates/${templateId}/reviews`, {
+        stars: 4,
+        text: "Good template",
+      });
+
+      // Duplicate review
+      const response = await buyer.client.post(
+        `/api/v1/templates/${templateId}/reviews`,
+        { stars: 3, text: "Changed my mind" },
+      );
+
+      expect(response.status).toBe(409);
+      expect(response.data.success).toBe(false);
+      expect(response.data.message).toContain("already reviewed");
+    });
+  });
+});

--- a/packages/api-tests/integration-tests/modules/template.test.ts
+++ b/packages/api-tests/integration-tests/modules/template.test.ts
@@ -133,6 +133,12 @@ describe("Template Community Routes", () => {
       expect(response.status).toBe(201);
       expect(response.data.success).toBe(true);
       expect(response.data.data.userId).toBe(user.id);
+
+      // Verify the template fields were snapshotted from the source form
+      const sourceForm = await prisma.form.findUnique({
+        where: { id: formId },
+      });
+      expect(response.data.data.fields).toEqual(sourceForm?.fields);
     });
   });
 

--- a/packages/api-tests/integration-tests/modules/template.test.ts
+++ b/packages/api-tests/integration-tests/modules/template.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { createAuthenticatedClient, createAnonymousClient } from "../setup/auth";
 import { cleanDb } from "../setup/db";
 import { prisma } from "@repo/db";
+import { randomUUID } from "crypto";
+import type { AxiosInstance } from "axios";
 
 // ---------------------------------------------------------------------------
 // Minimal valid fields payload (matches FormDefinitionSchema in @repo/types)
@@ -25,7 +27,7 @@ const SAMPLE_FIELDS = {
 
 /** Create a public community template via the API */
 async function createPublicTemplate(
-  client: Awaited<ReturnType<typeof createAuthenticatedClient>>["client"],
+  client: AxiosInstance,
   overrides: Record<string, unknown> = {},
 ) {
   return client.post("/api/v1/templates", {
@@ -118,7 +120,7 @@ describe("Template Community Routes", () => {
       // Create a form first so we have a valid formId
       const formResponse = await client.post("/api/v1/forms", {
         title: "Source Form",
-        slug: `source-form-${Date.now()}`,
+        slug: `source-form-${randomUUID()}`,
       });
       expect(formResponse.status).toBe(201);
       const formId = formResponse.data.data.id;
@@ -275,6 +277,22 @@ describe("Template Community Routes", () => {
       expect(response.data.success).toBe(false);
     });
 
+    it("should return 403 when attempting to purchase a private template", async () => {
+      const { client, user } = await createAuthenticatedClient();
+      const privateTemplate = await prisma.template.create({
+        data: { title: "Secret", isPublic: false, userId: user.id },
+      });
+
+      const buyer = await createAuthenticatedClient();
+      const response = await buyer.client.post(
+        `/api/v1/templates/${privateTemplate.id}/purchase`,
+      );
+
+      expect(response.status).toBe(403);
+      expect(response.data.success).toBe(false);
+      expect(response.data.message).toContain("private");
+    });
+
     it("should return 400 when a user tries to purchase their own template", async () => {
       const { client, user } = await createAuthenticatedClient();
 
@@ -294,7 +312,7 @@ describe("Template Community Routes", () => {
     it("should correctly add the template to the buyer's UserOwnedTemplate list", async () => {
       // Seller creates a template
       const seller = await createAuthenticatedClient({
-        email: `seller-${Date.now()}@test.com`,
+        email: `seller-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Purchasable Template",
@@ -304,7 +322,7 @@ describe("Template Community Routes", () => {
 
       // Buyer purchases the template
       const buyer = await createAuthenticatedClient({
-        email: `buyer-${Date.now()}@test.com`,
+        email: `buyer-${randomUUID()}@test.com`,
       });
       const purchaseRes = await buyer.client.post(
         `/api/v1/templates/${templateId}/purchase`,
@@ -337,7 +355,7 @@ describe("Template Community Routes", () => {
 
     it("should increment the template useCount after purchase", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller2-${Date.now()}@test.com`,
+        email: `seller2-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "UseCount Template",
@@ -345,7 +363,7 @@ describe("Template Community Routes", () => {
       const templateId = templateRes.data.data.id;
 
       const buyer = await createAuthenticatedClient({
-        email: `buyer2-${Date.now()}@test.com`,
+        email: `buyer2-${randomUUID()}@test.com`,
       });
       await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
 
@@ -357,7 +375,7 @@ describe("Template Community Routes", () => {
 
     it("should return 409 when the same user purchases the same template twice", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller3-${Date.now()}@test.com`,
+        email: `seller3-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Double Purchase Template",
@@ -365,7 +383,7 @@ describe("Template Community Routes", () => {
       const templateId = templateRes.data.data.id;
 
       const buyer = await createAuthenticatedClient({
-        email: `buyer3-${Date.now()}@test.com`,
+        email: `buyer3-${randomUUID()}@test.com`,
       });
 
       // First purchase
@@ -403,9 +421,20 @@ describe("Template Community Routes", () => {
       expect(response.status).toBe(401);
     });
 
+    it("should return 404 when reviewing a non-existent template", async () => {
+      const { client } = await createAuthenticatedClient();
+      const response = await client.post(
+        "/api/v1/templates/nonexistent-id/reviews",
+        { stars: 5 },
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.data.success).toBe(false);
+    });
+
     it("should return 403 if the user has NOT purchased the template", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller4-${Date.now()}@test.com`,
+        email: `seller4-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Review Gated Template",
@@ -414,7 +443,7 @@ describe("Template Community Routes", () => {
 
       // Stranger (never purchased)
       const stranger = await createAuthenticatedClient({
-        email: `stranger-${Date.now()}@test.com`,
+        email: `stranger-${randomUUID()}@test.com`,
       });
       const response = await stranger.client.post(
         `/api/v1/templates/${templateId}/reviews`,
@@ -444,7 +473,7 @@ describe("Template Community Routes", () => {
 
     it("should allow a review only after the user has purchased the template", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller5-${Date.now()}@test.com`,
+        email: `seller5-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Purchase Before Review Template",
@@ -453,7 +482,7 @@ describe("Template Community Routes", () => {
 
       // Buyer purchases the template
       const buyer = await createAuthenticatedClient({
-        email: `buyer5-${Date.now()}@test.com`,
+        email: `buyer5-${randomUUID()}@test.com`,
       });
       await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
 
@@ -480,7 +509,7 @@ describe("Template Community Routes", () => {
 
     it("should return 400 when stars is out of range (> 5)", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller6-${Date.now()}@test.com`,
+        email: `seller6-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Star Validation Template",
@@ -488,7 +517,7 @@ describe("Template Community Routes", () => {
       const templateId = templateRes.data.data.id;
 
       const buyer = await createAuthenticatedClient({
-        email: `buyer6-${Date.now()}@test.com`,
+        email: `buyer6-${randomUUID()}@test.com`,
       });
       await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
 
@@ -503,7 +532,7 @@ describe("Template Community Routes", () => {
 
     it("should return 409 when the user tries to leave a duplicate review", async () => {
       const seller = await createAuthenticatedClient({
-        email: `seller7-${Date.now()}@test.com`,
+        email: `seller7-${randomUUID()}@test.com`,
       });
       const templateRes = await createPublicTemplate(seller.client, {
         title: "Duplicate Review Template",
@@ -511,7 +540,7 @@ describe("Template Community Routes", () => {
       const templateId = templateRes.data.data.id;
 
       const buyer = await createAuthenticatedClient({
-        email: `buyer7-${Date.now()}@test.com`,
+        email: `buyer7-${randomUUID()}@test.com`,
       });
       await buyer.client.post(`/api/v1/templates/${templateId}/purchase`);
 

--- a/packages/api-tests/integration-tests/setup/db.ts
+++ b/packages/api-tests/integration-tests/setup/db.ts
@@ -6,6 +6,8 @@ import crypto from "crypto";
  */
 export async function cleanDb() {
   await prisma.$transaction([
+    prisma.templateReview.deleteMany({}),
+    prisma.userOwnedTemplate.deleteMany({}),
     prisma.response.deleteMany({}),
     prisma.form.deleteMany({}),
     prisma.session.deleteMany({}),

--- a/packages/db/prisma/migrations/20260630090000_add_template_community_tables/migration.sql
+++ b/packages/db/prisma/migrations/20260630090000_add_template_community_tables/migration.sql
@@ -55,3 +55,7 @@ ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_userId_f
 -- AddForeignKey
 ALTER TABLE "user_owned_templates" DROP CONSTRAINT IF EXISTS "user_owned_templates_templateId_fkey";
 ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "templates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_owned_templates" DROP CONSTRAINT IF EXISTS "user_owned_templates_clonedFormId_fkey";
+ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_clonedFormId_fkey" FOREIGN KEY ("clonedFormId") REFERENCES "forms"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260630090000_add_template_community_tables/migration.sql
+++ b/packages/db/prisma/migrations/20260630090000_add_template_community_tables/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "template_reviews" (
+    "id" TEXT NOT NULL,
+    "stars" INTEGER NOT NULL,
+    "text" TEXT,
+    "templateId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "template_reviews_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "user_owned_templates" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "clonedFormId" TEXT,
+    "purchasedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_owned_templates_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "template_reviews_templateId_userId_key" ON "template_reviews"("templateId", "userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "template_reviews_templateId_idx" ON "template_reviews"("templateId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "template_reviews_userId_idx" ON "template_reviews"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX IF NOT EXISTS "user_owned_templates_userId_templateId_key" ON "user_owned_templates"("userId", "templateId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "user_owned_templates_userId_idx" ON "user_owned_templates"("userId");
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "user_owned_templates_templateId_idx" ON "user_owned_templates"("templateId");
+
+-- AddForeignKey
+ALTER TABLE "template_reviews" DROP CONSTRAINT IF EXISTS "template_reviews_templateId_fkey";
+ALTER TABLE "template_reviews" ADD CONSTRAINT "template_reviews_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "templates"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "template_reviews" DROP CONSTRAINT IF EXISTS "template_reviews_userId_fkey";
+ALTER TABLE "template_reviews" ADD CONSTRAINT "template_reviews_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_owned_templates" DROP CONSTRAINT IF EXISTS "user_owned_templates_userId_fkey";
+ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_owned_templates" DROP CONSTRAINT IF EXISTS "user_owned_templates_templateId_fkey";
+ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "templates"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
# [Test] Template Community Routes — PR Summary

**Closes:** #55  
**Type:** `test`

---

## Overview

Implements the integration test suite for the Template Marketplace described in Issue #55. This PR adds comprehensive coverage for all required community template routes along with the supporting infrastructure required for reliable test execution.

---

## Changes Made

### Integration Tests

Added integration tests for:

- **`POST /api/v1/templates`**
  - Authentication
  - Request validation
  - Template creation using both `fields` and `formId`

- **`GET /api/v1/templates/community`**
  - Public template listing
  - Category filtering
  - Pagination
  - Creator information

- **`POST /api/v1/templates/:id/purchase`**
  - Authentication
  - Invalid, self, and duplicate purchase scenarios
  - Successful template purchase and cloning
  - `useCount` increment
  - Private template access validation

- **`POST /api/v1/templates/:id/reviews`**
  - Authentication
  - Purchase requirement
  - Creator restriction
  - Rating validation
  - Duplicate review prevention
  - Non-existent template handling

### Supporting Changes

- Added the required Prisma migration for community template tables.
- Updated the test database cleanup to include the new tables.
- Configured the API test package to load the monorepo root environment variables.
- Added typed test helpers and reliable unique test data generation.
- Added validation to ensure only public templates can be purchased.

---

## Test Results

```text
✓ All Template Marketplace integration tests passing
✓ Full API test suite passing
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added integration coverage for template creation, community listing, purchasing, and reviews.
- Verified authentication, validation, public-template filtering, categories, pagination, ownership, cloning, and review restrictions.
- Added database migration and test cleanup for template reviews and owned templates.
- Prevented users from purchasing private templates.
- Improved test configuration and coverage for cloned template data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->