### PR TITLE
feat(api): integrate OpenRouter SDK and implement AI form generation …

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -8,3 +8,5 @@ GOOGLE_CLIENT_SECRET=
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 FRONTEND_URL=http://localhost:3001
+OPENROUTER_API_KEY=your-key-here
+AI_MODEL=nvidia/nemotron-3-ultra-550b-a55b:free

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@openrouter/sdk": "^0.13.49",
     "@repo/db": "workspace:*",
     "@repo/types": "workspace:*",
     "axios": "^1.18.1",

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -295,11 +295,12 @@ export const generateForm: RequestHandler = asyncHandler(
 
     const { prompt } = req.body;
 
-    const systemPrompt = buildFormGenerationPrompt(prompt);
+    const systemPrompt = buildFormGenerationPrompt();
 
     const MAX_RETRIES = 1;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+
       try {
         const result = await aiClient.chat.send({
           chatRequest: {
@@ -311,6 +312,8 @@ export const generateForm: RequestHandler = asyncHandler(
             stream: false,
             responseFormat: { type: "json_object" },
           },
+        }, {
+          timeoutMs: 30000,
         });
 
         const raw = result.choices[0]?.message?.content;
@@ -337,10 +340,10 @@ export const generateForm: RequestHandler = asyncHandler(
         return;
       } catch (err) {
         if (attempt < MAX_RETRIES) continue;
+        console.error("AI form generation failed:", err);
         res.status(422).json({
           success: false,
           message: "AI response was invalid or failed to generate",
-          error: err instanceof Error ? err.message : String(err),
         });
         return;
       }

--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -5,6 +5,9 @@ import { isPrismaErrorCode } from "../utils/prisma";
 import { FormDefinitionSchema } from "@repo/types";
 import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
+import { config } from "../lib/env";
+import { aiClient } from "../lib/ai/client";
+import { buildFormGenerationPrompt } from "../lib/ai/prompt";
 import { formatZodErrors } from "@/middleware/validate";
 
 // ============================================
@@ -285,20 +288,66 @@ export const togglePublish: RequestHandler = asyncHandler(
 
 export const generateForm: RequestHandler = asyncHandler(
   async (req: Request, res: Response) => {
+    if (!config.ai.apiKey) {
+      res.status(503).json({ success: false, message: "AI service not configured" });
+      return;
+    }
+
     const { prompt } = req.body;
 
-    // TODO: Connect real LLM logic here later. 
-    // For now, return a basic mock structure so the frontend can test.
-    const dummyDefinition = {
-      version: "1.0",
-      elements: [
-        { id: "q1", type: "text", label: `AI generated question for: ${prompt || "General"}`, required: true }
-      ]
-    };
+    const systemPrompt = buildFormGenerationPrompt(prompt);
 
-    res.json({ success: true, data: { definition: dummyDefinition } });
+    const MAX_RETRIES = 1;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const result = await aiClient.chat.send({
+          chatRequest: {
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: prompt },
+            ],
+            model: config.ai.model,
+            stream: false,
+            responseFormat: { type: "json_object" },
+          },
+        });
+
+        const raw = result.choices[0]?.message?.content;
+        if (!raw) {
+          if (attempt < MAX_RETRIES) continue;
+          res.status(502).json({ success: false, message: "AI returned an empty response" });
+          return;
+        }
+
+        const parsed = JSON.parse(raw);
+        const validated = FormDefinitionSchema.safeParse(parsed);
+        if (validated.success) {
+          res.json({ success: true, data: { definition: validated.data } });
+          return;
+        }
+
+        if (attempt < MAX_RETRIES) continue;
+
+        res.status(422).json({
+          success: false,
+          message: "AI response did not match the expected form schema",
+          errors: validated.error.flatten(),
+        });
+        return;
+      } catch (err) {
+        if (attempt < MAX_RETRIES) continue;
+        res.status(422).json({
+          success: false,
+          message: "AI response was invalid or failed to generate",
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+    }
   }
 );
+
 
 // ============================================
 // GET /api/v1/forms/:id/analytics

--- a/apps/api/src/lib/ai/client.ts
+++ b/apps/api/src/lib/ai/client.ts
@@ -1,0 +1,6 @@
+import { OpenRouter } from "@openrouter/sdk";
+import { config } from "../env";
+
+export const aiClient = new OpenRouter({
+  apiKey: config.ai.apiKey,
+});

--- a/apps/api/src/lib/ai/prompt.ts
+++ b/apps/api/src/lib/ai/prompt.ts
@@ -2,7 +2,7 @@
  * Builds the system prompt for AI form generation.
  * Instructs the LLM to return a valid FormDefinition JSON object.
  */
-export function buildFormGenerationPrompt(userPrompt: string): string {
+export function buildFormGenerationPrompt(): string {
   return `You are an expert form builder. Generate a form based on the user's request.
 
 You MUST respond with ONLY a valid JSON object matching this exact structure:
@@ -32,8 +32,5 @@ You MUST respond with ONLY a valid JSON object matching this exact structure:
 - Every element MUST have a "label" (non-empty string)
 - Use "heading" or "paragraph" elements to organise sections
 - Generate 5-12 elements appropriate for the request
-- Return ONLY the JSON — no markdown, no explanation, no code fences
-
-## User request:
-${userPrompt}`;
+- Return ONLY the JSON — no markdown, no explanation, no code fences`;
 }

--- a/apps/api/src/lib/ai/prompt.ts
+++ b/apps/api/src/lib/ai/prompt.ts
@@ -1,0 +1,39 @@
+/**
+ * Builds the system prompt for AI form generation.
+ * Instructs the LLM to return a valid FormDefinition JSON object.
+ */
+export function buildFormGenerationPrompt(userPrompt: string): string {
+  return `You are an expert form builder. Generate a form based on the user's request.
+
+You MUST respond with ONLY a valid JSON object matching this exact structure:
+{
+  "version": "1.0",
+  "elements": [ ...array of form elements... ]
+}
+
+## Available element types:
+
+1. "textInput" - Single-line text { id, type, label, required?, description?, placeholder?, maxLength? }
+2. "textarea" - Multi-line text { id, type, label, required?, description?, placeholder?, rows?(2-20) }
+3. "rating" - Star rating { id, type, label, required?, description?, max?(2-10, default 5) }
+4. "multipleChoice" - Pick one { id, type, label, required?, description?, options: [{id, label}] } (min 2 options)
+5. "checkbox" - Pick many { id, type, label, required?, description?, options: [{id, label}] } (min 1 option)
+6. "dropdown" - Dropdown pick one { id, type, label, required?, description?, placeholder?, options: [{id, label}] } (min 2 options)
+7. "email" - Email input { id, type, label, required?, description?, placeholder? }
+8. "phone" - Phone input { id, type, label, required?, description?, placeholder? }
+9. "datePicker" - Date { id, type, label, required?, description?, minDate?, maxDate? }
+10. "heading" - Section heading { id, type, label, description?, level?: "h1"|"h2"|"h3" } (no required field)
+11. "paragraph" - Static text { id, type, label, description? } (no required field)
+
+## Rules:
+- Every element MUST have a unique "id" that is a valid UUID v4. Generate a unique, random UUID for each element (using only hexadecimal characters 0-9 and a-f).
+- Do NOT use letters beyond 'f' (such as g, h, i, j, k, l, m, etc.) in any UUID.
+- Every option inside "multipleChoice", "checkbox", and "dropdown" elements MUST also have a unique "id" in valid UUID v4 format. Generate a completely unique, random UUID for each option (do NOT use simple strings like "opt1" or "agree").
+- Every element MUST have a "label" (non-empty string)
+- Use "heading" or "paragraph" elements to organise sections
+- Generate 5-12 elements appropriate for the request
+- Return ONLY the JSON — no markdown, no explanation, no code fences
+
+## User request:
+${userPrompt}`;
+}

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -28,4 +28,8 @@ export const config = {
   frontend: {
     url: process.env.FRONTEND_URL || "http://localhost:3001",
   },
+  ai: {
+    apiKey: process.env.OPENROUTER_API_KEY || "",
+    model: process.env.AI_MODEL || "nvidia/nemotron-3-ultra-550b-a55b:free",
+  },
 };

--- a/apps/api/src/lib/form-schemas.ts
+++ b/apps/api/src/lib/form-schemas.ts
@@ -39,7 +39,7 @@ export const SubmitResponseSchema = z.object({
 });
 
 export const GenerateFormSchema = z.object({
-  prompt: z.string().trim().min(1, "Prompt cannot be empty").max(1000, "Prompt is too long").optional()
+  prompt: z.string().trim().min(1, "Prompt cannot be empty").max(1000, "Prompt is too long")
 });
 
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
       "name": "api",
       "version": "1.0.0",
       "dependencies": {
+        "@openrouter/sdk": "^0.13.49",
         "@repo/db": "workspace:*",
         "@repo/types": "workspace:*",
         "axios": "^1.18.1",
@@ -371,6 +372,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@openrouter/sdk": ["@openrouter/sdk@0.13.49", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-znnZPAi5YirL/4IHlWLIbnYiGXgB42LZiE6pqcXpu7wM7U1xOusJv42p4MOImUe2EP90fq5suoyZ+p2pz2vDow=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
@@ -1451,6 +1454,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@openrouter/sdk/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@prisma/engines/@prisma/get-platform": ["@prisma/get-platform@7.8.0", "", { "dependencies": { "@prisma/debug": "7.8.0" } }, "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw=="],
 

--- a/packages/db/prisma/migrations/20260701000001_add_cloned_form_fk/migration.sql
+++ b/packages/db/prisma/migrations/20260701000001_add_cloned_form_fk/migration.sql
@@ -1,2 +1,3 @@
 -- AlterTable
+ALTER TABLE "user_owned_templates" DROP CONSTRAINT IF EXISTS "user_owned_templates_clonedFormId_fkey";
 ALTER TABLE "user_owned_templates" ADD CONSTRAINT "user_owned_templates_clonedFormId_fkey" FOREIGN KEY ("clonedFormId") REFERENCES "forms"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
Integrates the OpenRouter SDK, sets up the prompt structure for AI form generation, and replaces the mock generation controller with a real schema-validated AI pipeline. Also resolves a database migration issue to ensure idempotency.

## Changes Made
- **API & SDK setup**: Added the `@openrouter/sdk` package dependency to `apps/api`.
- **Environment variables**: Introduced `OPENROUTER_API_KEY` and configurable `AI_MODEL` with fallbacks inside `env.ts` and `.env.example`.
- **AI client & prompt utils**:
  - Created `apps/api/src/lib/ai/client.ts` for unified OpenRouter client access.
  - Created `apps/api/src/lib/ai/prompt.ts` containing rules and schemas for element/option mapping.
- **Controller generation logic**:
  - Swapped the hardcoded mock in `POST /api/v1/forms/generate` with a real AI call.
  - Implemented automatic retry logic (max 2 attempts) for JSON parsing and Zod schema validations.
  - Enabled native JSON Mode (`responseFormat: { type: "json_object" }`).
  - Added schema validation via Zod's `FormDefinitionSchema`.
- **Database Migration**: Fixed a duplicate constraint error in migration `20260701000001_add_cloned_form_fk` by adding `DROP CONSTRAINT IF EXISTS`.

## Technical Decisions
- ESM ("type": "module") — The project already uses ESNext module resolution with Bun. Using export/import consistently avoids interop issues between CJS and ESM, and aligns with the existing tsconfig.json ("module": "ESNext").
- OpenRouter SDK — Chose OpenRouter over a direct provider SDK (OpenAI, Anthropic, etc.) because:
- Single SDK grants access to 400+ models (free and paid)
- Easy model swapping via AI_MODEL env var without code changes
- Built-in fallback routing if a provider is down
- chatRequest wrapper — The OpenRouter SDK's chat.send() expects the request body nested under a chatRequest key (separate from headers like HTTP-Referer). This is the SDK's own type signature, not an arbitrary choice. Our usage matches the SendChatCompletionRequestRequest type exactly

## Testing
- [x] All 39 integration tests pass (`bun run test` in `packages/api-tests` is fully clean)
- [x] Manual testing completed (using a local scratch script confirming model response formats, valid UUID v4 structures for options, and correct Zod checks)
- [x] No regressions introduced (all existing auth, onboarding, and dashboard API tests pass)

## Related Issues
- Fixes #95
- Fixes #96

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Integrated OpenRouter-based AI form generation.
- Replaced mock form responses with schema-validated generated forms and retry handling.
- Added configurable AI credentials and model settings.
- Made the cloned-form foreign key migration idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->