### PR TITLE
fix(api): inject server-side UUIDs post-LLM parse

### DIFF
--- a/apps/api/src/controllers/form.controller.ts
+++ b/apps/api/src/controllers/form.controller.ts
@@ -7,6 +7,7 @@ import { CreateFormInput, UpdateFormInput } from "../lib/form-schemas";
 import prisma from "../lib/db";
 import { config } from "../lib/env";
 import { aiClient } from "../lib/ai/client";
+import { injectIds } from "../lib/ai/inject-ids";
 import { buildFormGenerationPrompt } from "../lib/ai/prompt";
 import { formatZodErrors } from "@/middleware/validate";
 
@@ -324,6 +325,7 @@ export const generateForm: RequestHandler = asyncHandler(
         }
 
         const parsed = JSON.parse(raw);
+        injectIds(parsed);
         const validated = FormDefinitionSchema.safeParse(parsed);
         if (validated.success) {
           res.json({ success: true, data: { definition: validated.data } });

--- a/apps/api/src/lib/ai/inject-ids.test.ts
+++ b/apps/api/src/lib/ai/inject-ids.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "bun:test";
+import { injectIds } from "./inject-ids";
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("injectIds", () => {
+    it("replaces element ids with valid UUID v4s", () => {
+        const definition = {
+            elements: [
+                { id: "el_1", type: "textInput", label: "Name" },
+                { id: "el_2", type: "email", label: "Email" },
+            ],
+        };
+
+        injectIds(definition);
+
+        for (const el of definition.elements) {
+            expect(el.id).toMatch(UUID_REGEX);
+            expect(el.id).not.toBe("el_1");
+            expect(el.id).not.toBe("el_2");
+        }
+    });
+
+    it("replaces option ids inside dropdown/checkbox/multipleChoice with valid UUIDs", () => {
+        const definition = {
+            elements: [
+                {
+                    id: "el_1",
+                    type: "dropdown",
+                    label: "Subject",
+                    options: [
+                        { id: "opt_1", label: "Option A" },
+                        { id: "opt_2", label: "Option B" },
+                    ],
+                },
+            ],
+        };
+
+        injectIds(definition);
+
+        const [firstEl] = definition.elements;
+        const opts = firstEl?.options ?? [];
+        for (const opt of opts) {
+            expect(opt.id).toMatch(UUID_REGEX);
+            expect(opt.id).not.toBe("opt_1");
+            expect(opt.id).not.toBe("opt_2");
+        }
+    });
+
+    it("all injected ids are unique across elements and options", () => {
+        const definition = {
+            elements: [
+                { id: "el_1", type: "textInput", label: "Name" },
+                {
+                    id: "el_2",
+                    type: "dropdown",
+                    label: "Role",
+                    options: [
+                        { id: "opt_1", label: "Admin" },
+                        { id: "opt_2", label: "User" },
+                    ],
+                },
+            ],
+        };
+
+        injectIds(definition);
+
+        const [firstElement, secondElement] = definition.elements;
+        const allIds = [
+            firstElement?.id,
+            secondElement?.id,
+            ...(secondElement?.options ?? []).map((o) => o.id),
+        ];
+
+        const unique = new Set(allIds);
+        expect(unique.size).toBe(allIds.length);
+    });
+
+    it("handles empty elements array", () => {
+        const definition = { elements: [] };
+        injectIds(definition);
+        expect(definition.elements).toEqual([]);
+    });
+    
+    it("handles elements without options field", () => {
+        const definition = {
+            elements: [
+                { id: "el_1", type: "heading", label: "Title" },
+                { id: "el_2", type: "paragraph", label: "Text" },
+            ],
+        };
+        injectIds(definition);
+        for (const el of definition.elements) {
+            expect(el.id).toMatch(UUID_REGEX);
+        }
+    });
+    
+    it("handles null options gracefully", () => {
+        const definition = {
+            elements: [
+                { id: "el_1", type: "multipleChoice", label: "Pick", options: null },
+            ],
+        };
+        injectIds(definition);
+        expect(definition.elements[0]?.id).toMatch(UUID_REGEX);
+    });
+    
+    it("handles missing elements key gracefully", () => {
+        const definition = {};
+        injectIds(definition);
+        expect(definition).toEqual({});
+    });
+
+});

--- a/apps/api/src/lib/ai/inject-ids.test.ts
+++ b/apps/api/src/lib/ai/inject-ids.test.ts
@@ -1,114 +1,130 @@
 import { describe, it, expect } from "bun:test";
 import { injectIds } from "./inject-ids";
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
 
 describe("injectIds", () => {
-    it("replaces element ids with valid UUID v4s", () => {
-        const definition = {
-            elements: [
-                { id: "el_1", type: "textInput", label: "Name" },
-                { id: "el_2", type: "email", label: "Email" },
-            ],
-        };
+  it("replaces element ids with valid UUID v4s", () => {
+    const definition = {
+      elements: [
+        { id: "el_1", type: "textInput", label: "Name" },
+        { id: "el_2", type: "email", label: "Email" },
+      ],
+    };
 
-        injectIds(definition);
+    injectIds(definition);
 
-        for (const el of definition.elements) {
-            expect(el.id).toMatch(UUID_REGEX);
-            expect(el.id).not.toBe("el_1");
-            expect(el.id).not.toBe("el_2");
-        }
-    });
+    for (const el of definition.elements) {
+      expect(el.id).toMatch(UUID_REGEX);
+      expect(el.id).not.toBe("el_1");
+      expect(el.id).not.toBe("el_2");
+    }
+  });
 
-    it("replaces option ids inside dropdown/checkbox/multipleChoice with valid UUIDs", () => {
-        const definition = {
-            elements: [
-                {
-                    id: "el_1",
-                    type: "dropdown",
-                    label: "Subject",
-                    options: [
-                        { id: "opt_1", label: "Option A" },
-                        { id: "opt_2", label: "Option B" },
-                    ],
-                },
-            ],
-        };
+  it("replaces option ids inside dropdown/checkbox/multipleChoice with valid UUIDs", () => {
+    const definition = {
+      elements: [
+        {
+          id: "el_1",
+          type: "dropdown",
+          label: "Subject",
+          options: [
+            { id: "opt_1", label: "Option A" },
+            { id: "opt_2", label: "Option B" },
+          ],
+        },
+      ],
+    };
 
-        injectIds(definition);
+    injectIds(definition);
 
-        const [firstEl] = definition.elements;
-        const opts = firstEl?.options ?? [];
-        for (const opt of opts) {
-            expect(opt.id).toMatch(UUID_REGEX);
-            expect(opt.id).not.toBe("opt_1");
-            expect(opt.id).not.toBe("opt_2");
-        }
-    });
+    const [firstEl] = definition.elements;
+    const opts = firstEl?.options ?? [];
+    for (const opt of opts) {
+      expect(opt.id).toMatch(UUID_REGEX);
+      expect(opt.id).not.toBe("opt_1");
+      expect(opt.id).not.toBe("opt_2");
+    }
+  });
 
-    it("all injected ids are unique across elements and options", () => {
-        const definition = {
-            elements: [
-                { id: "el_1", type: "textInput", label: "Name" },
-                {
-                    id: "el_2",
-                    type: "dropdown",
-                    label: "Role",
-                    options: [
-                        { id: "opt_1", label: "Admin" },
-                        { id: "opt_2", label: "User" },
-                    ],
-                },
-            ],
-        };
+  it("all injected ids are unique across elements and options", () => {
+    const definition = {
+      elements: [
+        { id: "el_1", type: "textInput", label: "Name" },
+        {
+          id: "el_2",
+          type: "dropdown",
+          label: "Role",
+          options: [
+            { id: "opt_1", label: "Admin" },
+            { id: "opt_2", label: "User" },
+          ],
+        },
+      ],
+    };
 
-        injectIds(definition);
+    injectIds(definition);
 
-        const [firstElement, secondElement] = definition.elements;
-        const allIds = [
-            firstElement?.id,
-            secondElement?.id,
-            ...(secondElement?.options ?? []).map((o) => o.id),
-        ];
+    const [firstElement, secondElement] = definition.elements;
+    const allIds = [
+      firstElement?.id,
+      secondElement?.id,
+      ...(secondElement?.options ?? []).map((o) => o.id),
+    ];
 
-        const unique = new Set(allIds);
-        expect(unique.size).toBe(allIds.length);
-    });
+    const unique = new Set(allIds);
+    expect(unique.size).toBe(allIds.length);
+  });
 
-    it("handles empty elements array", () => {
-        const definition = { elements: [] };
-        injectIds(definition);
-        expect(definition.elements).toEqual([]);
-    });
-    
-    it("handles elements without options field", () => {
-        const definition = {
-            elements: [
-                { id: "el_1", type: "heading", label: "Title" },
-                { id: "el_2", type: "paragraph", label: "Text" },
-            ],
-        };
-        injectIds(definition);
-        for (const el of definition.elements) {
-            expect(el.id).toMatch(UUID_REGEX);
-        }
-    });
-    
-    it("handles null options gracefully", () => {
-        const definition = {
-            elements: [
-                { id: "el_1", type: "multipleChoice", label: "Pick", options: null },
-            ],
-        };
-        injectIds(definition);
-        expect(definition.elements[0]?.id).toMatch(UUID_REGEX);
-    });
-    
-    it("handles missing elements key gracefully", () => {
-        const definition = {};
-        injectIds(definition);
-        expect(definition).toEqual({});
-    });
+  it("handles empty elements array", () => {
+    const definition = { elements: [] };
+    injectIds(definition);
+    expect(definition.elements).toEqual([]);
+  });
 
+  it("handles elements without options field", () => {
+    const definition = {
+      elements: [
+        { id: "el_1", type: "heading", label: "Title" },
+        { id: "el_2", type: "paragraph", label: "Text" },
+      ],
+    };
+    injectIds(definition);
+    for (const el of definition.elements) {
+      expect(el.id).toMatch(UUID_REGEX);
+    }
+  });
+
+  it("handles null options gracefully", () => {
+    const definition = {
+      elements: [
+        { id: "el_1", type: "multipleChoice", label: "Pick", options: null },
+      ],
+    };
+    injectIds(definition);
+    expect(definition.elements[0]?.id).toMatch(UUID_REGEX);
+  });
+
+  it("handles missing elements key gracefully", () => {
+    const definition = {};
+    injectIds(definition);
+    expect(definition).toEqual({});
+  });
+
+  it("skips null and primitive entries in elements array", () => {
+    const definition = {
+      elements: [
+        null,
+        "string",
+        42,
+        { id: "el_1", type: "textInput", label: "Name" },
+      ],
+    };
+    injectIds(definition);
+    expect((definition.elements[3] as { id: string }).id).toMatch(UUID_REGEX);
+    expect(definition.elements[0]).toBeNull();
+    expect(definition.elements[1]).toBe("string");
+    expect(definition.elements[2]).toBe(42);
+  });
 });

--- a/apps/api/src/lib/ai/inject-ids.ts
+++ b/apps/api/src/lib/ai/inject-ids.ts
@@ -1,0 +1,13 @@
+export function injectIds(definition: { elements?: { id?: string; options?: { id?: string }[] | null }[] }) {
+
+    if (!Array.isArray(definition?.elements)) return;
+
+    for (const el of definition.elements) {
+        el.id = crypto.randomUUID();
+        if (Array.isArray(el.options)) {
+            for (const opt of el.options) {
+                opt.id = crypto.randomUUID();
+            }
+        }
+    }
+}

--- a/apps/api/src/lib/ai/inject-ids.ts
+++ b/apps/api/src/lib/ai/inject-ids.ts
@@ -1,13 +1,17 @@
-export function injectIds(definition: { elements?: { id?: string; options?: { id?: string }[] | null }[] }) {
+import { randomUUID } from "node:crypto";
 
-    if (!Array.isArray(definition?.elements)) return;
+export function injectIds(definition: { elements?: unknown[] }) {
+  if (!Array.isArray(definition?.elements)) return;
 
-    for (const el of definition.elements) {
-        el.id = crypto.randomUUID();
-        if (Array.isArray(el.options)) {
-            for (const opt of el.options) {
-                opt.id = crypto.randomUUID();
-            }
-        }
+  for (const el of definition.elements) {
+    if (!el || typeof el !== "object") continue;
+    (el as Record<string, unknown>).id = randomUUID();
+    const opts = (el as Record<string, unknown>).options;
+    if (Array.isArray(opts)) {
+      for (const opt of opts) {
+        if (!opt || typeof opt !== "object") continue;
+        (opt as Record<string, unknown>).id = randomUUID();
+      }
     }
+  }
 }

--- a/apps/api/src/lib/ai/prompt.ts
+++ b/apps/api/src/lib/ai/prompt.ts
@@ -1,6 +1,8 @@
 /**
  * Builds the system prompt for AI form generation.
  * Instructs the LLM to return a valid FormDefinition JSON object.
+  * Note: Placeholder IDs ("el_1", "opt_1") are replaced server-side
+  * with real UUIDs via injectIds() after parsing.
  */
 export function buildFormGenerationPrompt(): string {
   return `You are an expert form builder. Generate a form based on the user's request.
@@ -26,9 +28,8 @@ You MUST respond with ONLY a valid JSON object matching this exact structure:
 11. "paragraph" - Static text { id, type, label, description? } (no required field)
 
 ## Rules:
-- Every element MUST have a unique "id" that is a valid UUID v4. Generate a unique, random UUID for each element (using only hexadecimal characters 0-9 and a-f).
-- Do NOT use letters beyond 'f' (such as g, h, i, j, k, l, m, etc.) in any UUID.
-- Every option inside "multipleChoice", "checkbox", and "dropdown" elements MUST also have a unique "id" in valid UUID v4 format. Generate a completely unique, random UUID for each option (do NOT use simple strings like "opt1" or "agree").
+- Every element MUST have a unique "id" — use simple placeholders like "el_1", "el_2", etc.
+- Every option inside "multipleChoice", "checkbox", and "dropdown" elements MUST also have a unique "id" — use simple placeholders like "opt_1", "opt_2", etc.
 - Every element MUST have a "label" (non-empty string)
 - Use "heading" or "paragraph" elements to organise sections
 - Generate 5-12 elements appropriate for the request


### PR DESCRIPTION
## Summary
Replaces LLM-generated UUID placeholders with server-side `crypto.randomUUID()` injection after parsing the AI response. This eliminates the risk of duplicate or malformed IDs caused by non-uniform LLM token distribution.

## Changes Made
- Updated `apps/api/src/lib/ai/prompt.ts` to use simple placeholders (`el_1`, `opt_1`) instead of instructing the LLM to generate UUIDs
- Created `apps/api/src/lib/ai/inject-ids.ts` — a utility function that walks all elements and nested options and injects real UUIDs via `crypto.randomUUID()`
- Updated `apps/api/src/controllers/form.controller.ts` to call `injectIds()` on the parsed AI response before Zod schema validation
- Added `apps/api/src/lib/ai/inject-ids.test.ts` with 7 unit tests covering element injection, option injection, uniqueness, and edge cases (null options, missing elements, empty array)

## Testing
- All 8 unit tests pass (`bun test src/lib/ai/inject-ids.test.ts`)
- All 39 integration tests pass with no regressions
- TypeScript compiles cleanly (`bun x tsc --noEmit`)

## Related Issues
- Fixes #101

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Generate reliable, unique form and option IDs on the server instead of relying on AI output.
- Simplify AI instructions by using temporary placeholders.
- Cover nested options and edge cases with tests before saving or returning forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->