### PR TITLE
issue#72-refactor

### DIFF
--- a/apps/web/app/forms/[id]/edit/page.tsx
+++ b/apps/web/app/forms/[id]/edit/page.tsx
@@ -1,0 +1,5 @@
+import { EditFormPage } from "@/components/pages/edit-form";
+
+export default function EditForm() {
+  return <EditFormPage />;
+}

--- a/apps/web/components/pages/create-form.tsx
+++ b/apps/web/components/pages/create-form.tsx
@@ -705,7 +705,7 @@ export function CreateFormPage({
   const [expandedFieldId, setExpandedFieldId] = useState<string | null>(null);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(INITIAL_CHAT);
   const [chatInput, setChatInput] = useState("");
-  const [saveState, setSaveState] = useState<"unsaved" | "saving" | "saved">("unsaved");
+  const [saveState, setSaveState] = useState<"unsaved" | "saving" | "saved">(isEditMode ? "saved" : "unsaved");
   const [dropHighlight, setDropHighlight] = useState(false);
 
   /* ── Refs for timeout cleanup ─────────────────────────────────── */
@@ -730,6 +730,13 @@ export function CreateFormPage({
     });
   }, [chatMessages]);
 
+  /* ── Mutation helper — cancels stale save timers ────────────── */
+  const markUnsaved = useCallback(() => {
+    publishTimersRef.current.forEach(clearTimeout);
+    publishTimersRef.current = [];
+    setSaveState("unsaved");
+  }, []);
+
   /* ── Field Operations ────────────────────────────────────────── */
 
   const updateField = useCallback(
@@ -737,7 +744,7 @@ export function CreateFormPage({
       setFields((prev) =>
         prev.map((f) => (f.id === id ? { ...f, ...updates } : f))
       );
-      setSaveState("unsaved");
+      markUnsaved();
     },
     []
   );
@@ -756,13 +763,13 @@ export function CreateFormPage({
       next.splice(idx + 1, 0, clone);
       return next;
     });
-    setSaveState("unsaved");
+    markUnsaved();
   }, []);
 
   const deleteField = useCallback((id: string) => {
     setFields((prev) => prev.filter((f) => f.id !== id));
     setExpandedFieldId((prev) => (prev === id ? null : prev));
-    setSaveState("unsaved");
+    markUnsaved();
   }, []);
 
   const toggleExpandField = useCallback((id: string) => {
@@ -782,7 +789,7 @@ export function CreateFormPage({
         const newField = createField(snippetType as FormFieldType);
         setFields((prev) => [...prev, newField]);
         setExpandedFieldId(newField.id);
-        setSaveState("unsaved");
+        markUnsaved();
       }
     },
     []
@@ -807,7 +814,7 @@ export function CreateFormPage({
         return next;
       });
       setExpandedFieldId(newField.id);
-      setSaveState("unsaved");
+      markUnsaved();
     },
     []
   );
@@ -1045,7 +1052,7 @@ export function CreateFormPage({
                   value={formTitle}
                   onChange={(e) => {
                     setFormTitle(e.target.value);
-                    setSaveState("unsaved");
+                    markUnsaved();
                   }}
                   placeholder="Form Title"
                 />
@@ -1054,7 +1061,7 @@ export function CreateFormPage({
                   value={formDescription}
                   onChange={(e) => {
                     setFormDescription(e.target.value);
-                    setSaveState("unsaved");
+                    markUnsaved();
                   }}
                   placeholder="Add a description..."
                 />
@@ -1098,7 +1105,7 @@ export function CreateFormPage({
                   values={fields}
                   onReorder={(newFields) => {
                     setFields(newFields);
-                    setSaveState("unsaved");
+                    markUnsaved();
                   }}
                   className="w-full flex flex-col gap-3"
                 >
@@ -1120,7 +1127,7 @@ export function CreateFormPage({
                           next.splice(to, 0, removed);
                           return next;
                         });
-                        setSaveState("unsaved");
+                        markUnsaved();
                       }}
                       onSnippetDropOnCard={handleSnippetDropOnCard}
                     />

--- a/apps/web/components/pages/create-form.tsx
+++ b/apps/web/components/pages/create-form.tsx
@@ -27,6 +27,7 @@ import {
   Bot,
   User,
   Upload,
+  Save,
   GripVertical,
   ChevronDown,
   ScrollText,
@@ -42,7 +43,7 @@ import {
 
 /* ── Types ───────────────────────────────────────────────────────── */
 
-type FormFieldType =
+export type FormFieldType =
   | "textInput"
   | "numberInput"
   | "email"
@@ -51,12 +52,12 @@ type FormFieldType =
   | "checkbox"
   | "rating";
 
-type FieldOption = {
+export type FieldOption = {
   id: string;
   label: string;
 };
 
-type FormField = {
+export type FormField = {
   id: string;
   type: FormFieldType;
   label: string;
@@ -685,12 +686,22 @@ function ChatBubble({ message }: { message: ChatMessage }) {
 
 /* ── Main Create Form Component ──────────────────────────────────── */
 
-export function CreateFormPage() {
+export function CreateFormPage({
+  initialTitle,
+  initialDescription,
+  initialFields,
+  isEditMode = false,
+}: {
+  initialTitle?: string;
+  initialDescription?: string;
+  initialFields?: FormField[];
+  isEditMode?: boolean;
+} = {}) {
   const [mode, setMode] = useState<"chat" | "manual">("manual");
-  const [formTitle, setFormTitle] = useState("Untitled Form");
-  const [formDescription, setFormDescription] = useState("");
+  const [formTitle, setFormTitle] = useState(initialTitle ?? "Untitled Form");
+  const [formDescription, setFormDescription] = useState(initialDescription ?? "");
   const [formType, setFormType] = useState<FormType>("scroll");
-  const [fields, setFields] = useState<FormField[]>([]);
+  const [fields, setFields] = useState<FormField[]>(initialFields ?? []);
   const [expandedFieldId, setExpandedFieldId] = useState<string | null>(null);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(INITIAL_CHAT);
   const [chatInput, setChatInput] = useState("");
@@ -872,11 +883,14 @@ export function CreateFormPage() {
             <span className="text-sm text-muted-foreground hidden md:block">
               {saveState === "unsaved" && "Unsaved changes"}
               {saveState === "saving" && "Saving..."}
-              {saveState === "saved" && "✓ Published"}
+              {saveState === "saved" && (isEditMode ? "✓ Saved" : "✓ Published")}
             </span>
             <Button size="sm" onClick={handlePublish}>
-              <Upload className="size-3.5" />
-              Publish
+              {isEditMode ? (
+                <><Save className="size-3.5" /> Save Changes</>
+              ) : (
+                <><Upload className="size-3.5" /> Publish</>
+              )}
             </Button>
           </div>
         </div>

--- a/apps/web/components/pages/edit-form.tsx
+++ b/apps/web/components/pages/edit-form.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { CreateFormPage } from "@/components/pages/create-form";
+import type { FormField } from "@/components/pages/create-form";
+
+/* ── Mock Data: Pre-populated form for editing ───────────────────── */
+
+const MOCK_EDIT_FIELDS: FormField[] = [
+  {
+    id: "field-edit-1",
+    type: "textInput",
+    label: "Full Name",
+    placeholder: "Enter your full name",
+    required: true,
+    validateFormat: false,
+    options: [],
+  },
+  {
+    id: "field-edit-2",
+    type: "email",
+    label: "Work Email",
+    placeholder: "name@company.com",
+    required: true,
+    validateFormat: true,
+    options: [],
+  },
+  {
+    id: "field-edit-3",
+    type: "dropdown",
+    label: "Role",
+    placeholder: "Select your role",
+    required: false,
+    validateFormat: false,
+    options: [
+      { id: "opt-1", label: "Junior Developer" },
+      { id: "opt-2", label: "Senior Developer" },
+      { id: "opt-3", label: "Tech Lead" },
+      { id: "opt-4", label: "Engineering Manager" },
+    ],
+  },
+];
+
+const MOCK_EDIT_TITLE = "Event Registration";
+const MOCK_EDIT_DESCRIPTION =
+  "Please fill out the form below to secure your spot at the upcoming developer summit.";
+
+/* ── Edit Form Page Component ────────────────────────────────────── */
+
+export function EditFormPage() {
+  return (
+    <CreateFormPage
+      initialTitle={MOCK_EDIT_TITLE}
+      initialDescription={MOCK_EDIT_DESCRIPTION}
+      initialFields={MOCK_EDIT_FIELDS}
+      isEditMode
+    />
+  );
+}

--- a/apps/web/components/pages/form-details.tsx
+++ b/apps/web/components/pages/form-details.tsx
@@ -288,12 +288,14 @@ export function FormDetailsPage() {
                   <TooltipContent>Export raw JSON data</TooltipContent>
                 </Tooltip>
 
-                <Link href={`/forms/${MOCK_FORM.id}/edit`}>
-                  <Button size="sm" className="gap-2">
-                    <Pencil className="size-4" />
-                    Edit Form
-                  </Button>
-                </Link>
+                <Button
+                  size="sm"
+                  className="gap-2"
+                  render={<Link href={`/forms/${MOCK_FORM.id}/edit`} />}
+                >
+                  <Pencil className="size-4" />
+                  Edit Form
+                </Button>
               </div>
             </motion.div>
           </div>

--- a/apps/web/components/pages/form-details.tsx
+++ b/apps/web/components/pages/form-details.tsx
@@ -288,7 +288,7 @@ export function FormDetailsPage() {
                   <TooltipContent>Export raw JSON data</TooltipContent>
                 </Tooltip>
 
-                <Link href="/forms/create">
+                <Link href={`/forms/${MOCK_FORM.id}/edit`}>
                   <Button size="sm" className="gap-2">
                     <Pencil className="size-4" />
                     Edit Form


### PR DESCRIPTION
## 📝 Description

This PR implements the frontend UI for **Issue #72 (UI: Edit Form `edit/[id]`)**. It enables editing an existing form by reusing the core Form Builder interface (`CreateFormPage`), pre-populating it with mock initial form data, and providing edit-mode save feedback.

The implementation preserves the project's architecture (thin App Router route wrapping a page component) and introduces zero breaking changes to the existing form creation flow (`/forms/create`).

---

## 🚀 Key Features & Changes

### 1. Reusable Builder Component Enhancements (`apps/web/components/pages/create-form.tsx`)
- Exported key types (`FormField`, `FormFieldType`, `FieldOption`) for reuse across page modules.
- Extended `CreateFormPage` to accept optional initialization props:
  - `initialTitle?: string`
  - `initialDescription?: string`
  - `initialFields?: FormField[]`
  - `isEditMode?: boolean`
- **Dynamic Header & Status Controls**:
  - In creation mode (`/forms/create`), top action reads **"Publish"** with **"✓ Published"** status.
  - In edit mode (`/forms/[id]/edit`), top action dynamically switches to **"Save Changes"** (with `Save` icon) and **"✓ Saved"** status.

### 2. Edit Form Page Wrapper (`apps/web/components/pages/edit-form.tsx`)
- Created `EditFormPage` wrapper component pre-loaded with mock data matching the design specification:
  - **Form Title**: "Event Registration"
  - **Description**: "Please fill out the form below to secure your spot at the upcoming developer summit."
  - **Pre-populated Fields**:
    1. **Full Name**: Required text input
    2. **Work Email**: Required email input with format validation
    3. **Role**: Dropdown select with options (*Junior Developer*, *Senior Developer*, *Tech Lead*, *Engineering Manager*)

### 3. Route Layer (`apps/web/app/forms/[id]/edit/page.tsx`)
- Added thin App Router page at `/forms/[id]/edit` rendering `<EditFormPage />`.

### 4. Details Page Integration (`apps/web/components/pages/form-details.tsx`)
- Updated the "Edit Form" action button on the Form Details page to route to `/forms/${MOCK_FORM.id}/edit` instead of `/forms/create`.

---

## 🧪 Verification & Testing

- ✅ **Build Check**: `bun run build --filter=web` succeeded with zero TypeScript errors or warnings.
- ✅ **Route Verification**:
  - `/forms/[id]/edit` → Loads pre-populated form in edit mode with "Save Changes" action.
  - `/forms/create` → Loads empty form builder in creation mode with "Publish" action (no regressions).
  - `/forms/1` → "Edit Form" button navigates directly to `/forms/FRM-892X/edit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added an edit form experience with pre-populated Event Registration data.
- Added Save Changes and saved-status feedback for edited forms.
- Connected Form Details to the new edit route.
- Preserved the existing form creation flow.
- Verified the build successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->