### PR TITLE
feat: setup Redux Toolkit store & Next.js App Router provider (#111)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
+import ReduxProvider from "@/providers/redux-provider";
 import "./globals.css";
 
 const inter = Inter({
@@ -31,7 +32,7 @@ export default function RootLayout({
       className={`h-full antialiased ${inter.variable} ${spaceGrotesk.variable}`}
     >
       <body className="min-h-full flex flex-col font-[family-name:var(--font-inter)]">
-        {children}
+        <ReduxProvider>{children}</ReduxProvider>
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,13 +9,15 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.12.0",
     "@repo/types": "workspace:*",
     "@repo/ui": "*",
     "lucide-react": "^1.23.0",
     "motion": "^12.42.2",
     "next": "16.2.9",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-redux": "^9.3.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/web/providers/redux-provider.tsx
+++ b/apps/web/providers/redux-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+import { Provider } from "react-redux";
+import { makeStore, type AppStore } from "@/store";
+
+interface ReduxProviderProps {
+  children: React.ReactNode;
+}
+
+export default function ReduxProvider({ children }: ReduxProviderProps) {
+  // Lazy initial state function ensures makeStore() is only invoked once per client instance
+  const [store] = useState<AppStore>(() => makeStore());
+
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/apps/web/store/hooks.ts
+++ b/apps/web/store/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector, useStore } from "react-redux";
+import type { RootState, AppDispatch, AppStore } from "./store";
+
+// Use throughout your app instead of plain `useDispatch`, `useSelector`, and `useStore`
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();
+export const useAppStore = useStore.withTypes<AppStore>();

--- a/apps/web/store/index.ts
+++ b/apps/web/store/index.ts
@@ -1,0 +1,3 @@
+export { makeStore } from "./store";
+export type { AppStore, RootState, AppDispatch } from "./store";
+export { useAppDispatch, useAppSelector, useAppStore } from "./hooks";

--- a/apps/web/store/store.ts
+++ b/apps/web/store/store.ts
@@ -1,0 +1,16 @@
+import { configureStore } from "@reduxjs/toolkit";
+
+export const makeStore = () => {
+  return configureStore({
+    reducer: {
+      // Slices (like builderSlice, uiSlice) will be registered here
+    },
+    devTools: process.env.NODE_ENV !== "production",
+  });
+};
+
+// Infer the type of makeStore
+export type AppStore = ReturnType<typeof makeStore>;
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<AppStore["getState"]>;
+export type AppDispatch = AppStore["dispatch"];

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.12.0",
         "@repo/types": "workspace:*",
         "@repo/ui": "*",
         "lucide-react": "^1.23.0",
@@ -46,6 +47,7 @@
         "next": "16.2.9",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-redux": "^9.3.0",
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -421,6 +423,8 @@
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
+
     "@repo/api-tests": ["@repo/api-tests@workspace:packages/api-tests"],
 
     "@repo/db": ["@repo/db@workspace:packages/db"],
@@ -436,6 +440,8 @@
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -522,6 +528,8 @@
     "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
 
     "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.61.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.61.1", "@typescript-eslint/type-utils": "8.61.1", "@typescript-eslint/utils": "8.61.1", "@typescript-eslint/visitor-keys": "8.61.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.61.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ=="],
 
@@ -945,6 +953,8 @@
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "immer": ["immer@11.1.16", "", {}, "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
@@ -1255,7 +1265,13 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
+
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 


### PR DESCRIPTION
## Summary
Sets up Redux Toolkit and React-Redux in `apps/web` to provide a centralized client-side state management foundation for interactive features (e.g., form builder canvas, modals, and device preview). Includes an SSR-safe Next.js App Router Provider and strongly-typed hooks.

## Changes Made
- Installed `@reduxjs/toolkit` and `react-redux` dependencies in `apps/web`.
- Created store configuration factory `makeStore()` and inferred types (`AppStore`, `RootState`, `AppDispatch`) in `apps/web/store/store.ts`.
- Configured strongly-typed hooks (`useAppDispatch`, `useAppSelector`, `useAppStore`) using modern `.withTypes<...>()` API in `apps/web/store/hooks.ts`.
- Created barrel export in `apps/web/store/index.ts`.
- Created client component `ReduxProvider` with lazy state initialization (`useState(() => makeStore())`) in `apps/web/providers/redux-provider.tsx` to prevent cross-request SSR state leakage and satisfy React 19 ESLint rules.
- Wrapped Next.js root layout with `<ReduxProvider>` in `apps/web/app/layout.tsx`.

## Testing
- Ran TypeScript checks (`bun x tsc --noEmit`) with 0 errors.
- Verified Next.js dev and build compilation with App Router layout wrapping.
- Confirmed zero lint errors on all newly introduced files.

## Related Issues
- Fixes #111

## Screenshots (if applicable)
N/A (Foundational infrastructure setup)

## Checklist
- [x] Code follows project conventions
- [x] Tests pass
- [x] Documentation updated
- [x] No linting errors (in new files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Add Redux Toolkit and React-Redux support to `apps/web`.
- Add typed Redux store utilities and hooks.
- Add an SSR-safe `ReduxProvider`.
- Wrap the Next.js root layout with `ReduxProvider`.
- Verify TypeScript, build, and lint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->